### PR TITLE
feat: implement single source of truth versioning with setuptools-scm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ help:
 	@echo "  build       - Build development container"
 	@echo "  clean       - Clean up containers and volumes"
 	@echo "  drift-check - Check for JustiFi API changes"
+	@echo "  version-check - Check version synchronization"
 	@echo ""
 	@echo "Note: Configure Cursor to connect to: python main.py"
 
@@ -79,4 +80,9 @@ clean:
 # Check for JustiFi API drift/changes
 drift-check: env-check
 	@echo "🔍 Checking for JustiFi API changes..."
-	python scripts/ci-drift-check.py 
+	python scripts/ci-drift-check.py
+
+# Check version synchronization
+version-check:
+	@echo "🔍 Checking version synchronization..."
+	./scripts/check-version-sync.sh 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,214 @@
+# Single Source of Truth Versioning
+
+## Overview
+
+The JustiFi MCP Server uses a **single source of truth versioning system** where Git tags are the authoritative version source. This eliminates version mismatches and ensures all components stay synchronized.
+
+## How It Works
+
+### 🎯 Single Source of Truth: Git Tags
+
+```
+Git Tag (v1.0.1) → Python Version (1.0.1) → NPM Version (1.0.1)
+```
+
+1. **Git Tag**: The authoritative version (e.g., `v1.0.1`)
+2. **Python Version**: Auto-derived from Git tag via `setuptools-scm`
+3. **NPM Version**: Synced to match Git tag via release script
+
+### 🔄 Automatic Version Derivation
+
+- **setuptools-scm** reads Git tags and automatically sets Python package version
+- **Release script** updates NPM package.json to match Git tag
+- **CI validation** ensures all versions stay synchronized
+
+## Version Sources
+
+| Component | Location | Source | Example |
+|-----------|----------|--------|---------|
+| **Git Tag** | Repository | Manual/Script | `v1.0.1` |
+| **Python Package** | `pyproject.toml` | setuptools-scm | `1.0.1` |
+| **NPM Package** | `npx-wrapper/package.json` | Release script | `1.0.1` |
+| **Python Module** | `justifi_mcp/__init__.py` | setuptools-scm | `1.0.1` |
+
+## Creating Releases
+
+### Method 1: Automated Release Script (Recommended)
+
+```bash
+# Create a new release - updates everything automatically
+./scripts/release-automated.sh v1.0.1
+```
+
+**What it does:**
+1. ✅ Validates version format and prerequisites
+2. ✅ Runs tests to ensure quality
+3. ✅ Updates NPM package.json to match version
+4. ✅ Commits version changes
+5. ✅ Creates Git tag (triggers Python version via setuptools-scm)
+6. ✅ Pushes changes and tag
+7. ✅ Creates GitHub release
+
+### Method 2: Manual Process
+
+```bash
+# 1. Update NPM version
+cd npx-wrapper
+npm version 1.0.1 --no-git-tag-version
+cd ..
+
+# 2. Commit changes
+git add npx-wrapper/package.json
+git commit -m "chore: sync NPM version to 1.0.1 for release"
+
+# 3. Create Git tag (triggers Python version)
+git tag -a v1.0.1 -m "Release v1.0.1"
+git push origin main --tags
+
+# 4. Create GitHub release
+gh release create v1.0.1 --generate-notes
+```
+
+## Version Validation
+
+### Check Version Sync
+
+```bash
+# Check if all versions are synchronized
+make version-check
+# or
+./scripts/check-version-sync.sh
+```
+
+**Example output:**
+```
+🔍 Checking version synchronization...
+
+📊 Version Report:
+  Git Tag:     v1.0.1
+  NPM:         1.0.1
+  Python:      1.0.1
+
+✅ All versions are synchronized!
+```
+
+### CI Integration
+
+The version validation runs in CI to prevent version mismatches:
+
+```yaml
+# .github/workflows/ci.yml
+- name: Check version synchronization
+  run: ./scripts/check-version-sync.sh
+```
+
+## Development Workflow
+
+### Development Versions
+
+During development (no Git tag):
+- **Python**: `0.0.0` (setuptools-scm fallback)
+- **NPM**: Whatever is in package.json
+- **Git**: No tag
+
+### Release Versions
+
+After creating a release tag:
+- **Python**: Auto-derived from Git tag (e.g., `1.0.1`)
+- **NPM**: Synced to match Git tag (e.g., `1.0.1`)
+- **Git**: Authoritative source (e.g., `v1.0.1`)
+
+## Benefits
+
+### ✅ Eliminates Version Mismatches
+- Impossible to have different versions across components
+- Git tag is the single source of truth
+- Automatic synchronization prevents human error
+
+### ✅ Simplified Release Process
+- One command creates entire release
+- No manual version updates needed
+- Automatic CI validation
+
+### ✅ Developer Experience
+- Clear version hierarchy
+- Automatic Python version derivation
+- Consistent across all environments
+
+## Troubleshooting
+
+### Version Mismatch Detected
+
+```bash
+❌ ERROR: NPM version (1.0.0) doesn't match Git tag (v1.0.1)
+   Expected NPM version: 1.0.1
+```
+
+**Solution:**
+```bash
+# Use the automated release script
+./scripts/release-automated.sh v1.0.1
+```
+
+### Python Version Not Available
+
+If `setuptools-scm` can't determine version:
+- Ensure you're in a Git repository
+- Check that Git tags exist
+- Verify setuptools-scm is installed
+
+### setuptools-scm Configuration
+
+```toml
+# pyproject.toml
+[tool.setuptools_scm]
+write_to = "justifi_mcp/_version.py"
+fallback_version = "0.0.0"
+```
+
+## Migration from Old System
+
+### Before (Multiple Sources)
+```
+pyproject.toml: version = "2.0.0-dev"
+package.json: "version": "1.0.0"
+__init__.py: __version__ = "2.0.0-dev"
+Git tag: v1.0.0
+```
+
+### After (Single Source)
+```
+Git tag: v1.0.1 (authoritative)
+├── Python: 1.0.1 (auto-derived)
+├── NPM: 1.0.1 (synced)
+└── Module: 1.0.1 (auto-derived)
+```
+
+## Best Practices
+
+1. **Always use the automated release script** for releases
+2. **Run version-check** before creating releases
+3. **Follow semantic versioning** (v1.0.1, v1.1.0, v2.0.0)
+4. **Test installations** after releases
+5. **Use CI validation** to prevent version drift
+
+## Commands Reference
+
+```bash
+# Create release
+./scripts/release-automated.sh v1.0.1
+
+# Check version sync
+make version-check
+
+# Validate in CI
+./scripts/check-version-sync.sh
+
+# Get current Python version
+python -c "import justifi_mcp; print(justifi_mcp.__version__)"
+
+# Get current NPM version
+node -p "require('./npx-wrapper/package.json').version"
+```
+
+This system ensures that version mismatches are impossible and releases are fully automated and reliable. 

--- a/justifi_mcp/__init__.py
+++ b/justifi_mcp/__init__.py
@@ -59,6 +59,9 @@ def _create_tool_schemas():
 
 TOOL_SCHEMAS = _create_tool_schemas()
 
-__version__ = "2.0.0-dev"
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = "0.0.0"
 __author__ = "JustiFi"
 __description__ = "Multi-framework payment processing toolkit for AI agents"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=45", "wheel"]
+requires = ["setuptools>=64", "setuptools-scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "justifi-mcp-server"
-version = "2.0.0-dev"
+dynamic = ["version"]
 description = "JustiFi MCP Server with multi-framework support for payment processing integration"
 authors = [{ name = "JustiFi MCP Team", email = "support@justifi.ai" }]
 license = "MIT"
@@ -56,6 +56,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "respx>=0.20.0",
     "ruff>=0.1.0",
+    "setuptools-scm>=8.0.0",  # For version management
     "watchdog",               # Only for development auto-restart
     # Note: mypy excluded from standard workflow - focus on runtime correctness
     # "mypy>=1.0.0",
@@ -115,3 +116,7 @@ known-first-party = ["python", "modelcontextprotocol", "justifi_mcp", "tests"]
 where = ["."]
 include = ["python*", "modelcontextprotocol*", "justifi_mcp*"]
 exclude = ["tests*", "archive*", "eval*", "docker*", "examples*", "scripts*"]
+
+[tool.setuptools_scm]
+write_to = "justifi_mcp/_version.py"
+fallback_version = "0.0.0"

--- a/scripts/check-version-sync.sh
+++ b/scripts/check-version-sync.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Version Sync Validation Script
+# Ensures all version sources are synchronized
+# Used in CI to prevent version mismatches
+
+set -e
+
+echo "🔍 Checking version synchronization..."
+
+# Get versions from different sources
+GIT_TAG=$(git describe --tags --exact-match 2>/dev/null || echo "none")
+NPM_VERSION=$(node -p "require('./npx-wrapper/package.json').version" 2>/dev/null || echo "none")
+
+# Try to get Python version (may not work if setuptools-scm hasn't run)
+PYTHON_VERSION="unknown"
+if [ -f "justifi_mcp/_version.py" ]; then
+    PYTHON_VERSION=$(python -c "from justifi_mcp._version import version; print(version)" 2>/dev/null || echo "unknown")
+elif command -v python &> /dev/null; then
+    # Try to get version via setuptools-scm directly
+    PYTHON_VERSION=$(python -c "import setuptools_scm; print(setuptools_scm.get_version())" 2>/dev/null || echo "unknown")
+fi
+
+echo ""
+echo "📊 Version Report:"
+echo "  Git Tag:     $GIT_TAG"
+echo "  NPM:         $NPM_VERSION"  
+echo "  Python:      $PYTHON_VERSION"
+echo ""
+
+# Validation logic
+ERRORS=0
+
+if [ "$GIT_TAG" != "none" ]; then
+    # We have a git tag, check if NPM version matches
+    GIT_VERSION_NO_V=${GIT_TAG#v}  # Remove 'v' prefix
+    
+    if [ "$NPM_VERSION" != "$GIT_VERSION_NO_V" ]; then
+        echo "❌ ERROR: NPM version ($NPM_VERSION) doesn't match Git tag ($GIT_TAG)"
+        echo "   Expected NPM version: $GIT_VERSION_NO_V"
+        ERRORS=$((ERRORS + 1))
+    fi
+    
+    # Check Python version if available
+    if [ "$PYTHON_VERSION" != "unknown" ] && [ "$PYTHON_VERSION" != "$GIT_VERSION_NO_V" ]; then
+        echo "❌ ERROR: Python version ($PYTHON_VERSION) doesn't match Git tag ($GIT_TAG)"
+        echo "   Expected Python version: $GIT_VERSION_NO_V"
+        ERRORS=$((ERRORS + 1))
+    fi
+else
+    # No git tag, check if we're in development
+    if [ "$NPM_VERSION" = "none" ]; then
+        echo "❌ ERROR: Could not determine NPM version"
+        ERRORS=$((ERRORS + 1))
+    fi
+    
+    echo "ℹ️  No Git tag found - assuming development mode"
+fi
+
+# Final result
+if [ $ERRORS -eq 0 ]; then
+    echo "✅ All versions are synchronized!"
+    exit 0
+else
+    echo ""
+    echo "❌ Found $ERRORS version synchronization error(s)"
+    echo ""
+    echo "🔧 To fix version mismatches:"
+    echo "1. Use the automated release script: ./scripts/release-automated.sh v1.0.1"
+    echo "2. Or manually sync versions and create a proper Git tag"
+    echo ""
+    exit 1
+fi 

--- a/scripts/manual-release.sh
+++ b/scripts/manual-release.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Manual Release Script for JustiFi MCP Server
+# Usage: ./scripts/manual-release.sh v1.0.0
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 v1.0.0"
+    exit 1
+fi
+
+VERSION=$1
+
+# Validate version format (should start with v)
+if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version must be in format vX.Y.Z (e.g., v1.0.0)"
+    exit 1
+fi
+
+# Check if we're on main branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "Error: Must be on main branch to create a release"
+    echo "Current branch: $CURRENT_BRANCH"
+    exit 1
+fi
+
+# Check if working directory is clean
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Error: Working directory is not clean. Please commit or stash changes."
+    exit 1
+fi
+
+# Check if tag already exists
+if git tag -l | grep -q "^$VERSION$"; then
+    echo "Error: Tag $VERSION already exists"
+    exit 1
+fi
+
+echo "Creating release $VERSION..."
+
+# Pull latest changes
+git pull origin main
+
+# Create and push tag
+git tag -a "$VERSION" -m "Release $VERSION"
+git push origin "$VERSION"
+
+echo "✅ Release $VERSION created successfully!"
+echo "🔗 View release at: https://github.com/justifi-tech/mcp-server/releases/tag/$VERSION"
+echo ""
+echo "Next steps:"
+echo "1. Go to GitHub releases and edit the release notes"
+echo "2. Mark as latest release if appropriate" 

--- a/scripts/release-automated.sh
+++ b/scripts/release-automated.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# Automated Release Script for JustiFi MCP Server
+# Single Source of Truth Versioning with Git Tags
+# Usage: ./scripts/release-automated.sh v1.0.1
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 v1.0.1"
+    echo ""
+    echo "This script implements single source of truth versioning:"
+    echo "1. Git tag becomes the authoritative version"
+    echo "2. Python version auto-derived via setuptools-scm"
+    echo "3. NPM package.json updated to match"
+    echo "4. All versions stay in sync automatically"
+    exit 1
+fi
+
+VERSION=$1
+VERSION_NO_V=${VERSION#v}  # Remove 'v' prefix
+
+# Validate version format (should start with v)
+if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "❌ Error: Version must be in format vX.Y.Z (e.g., v1.0.1)"
+    exit 1
+fi
+
+# Check if we're on main branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "❌ Error: Must be on main branch to create a release"
+    echo "Current branch: $CURRENT_BRANCH"
+    exit 1
+fi
+
+# Check if working directory is clean
+if [ -n "$(git status --porcelain)" ]; then
+    echo "❌ Error: Working directory is not clean. Please commit or stash changes."
+    exit 1
+fi
+
+# Check if tag already exists
+if git tag -l | grep -q "^$VERSION$"; then
+    echo "❌ Error: Tag $VERSION already exists"
+    exit 1
+fi
+
+echo "🚀 Starting automated release $VERSION..."
+echo ""
+
+# Pull latest changes
+echo "📥 Pulling latest changes..."
+git pull origin main
+
+# Run tests to ensure everything works
+echo "🧪 Running tests..."
+if command -v make &> /dev/null; then
+    make test
+else
+    echo "⚠️  Make not available, skipping tests"
+fi
+
+# Update NPM package.json to match the new version
+echo "📦 Updating NPM package.json to $VERSION_NO_V..."
+cd npx-wrapper
+npm version $VERSION_NO_V --no-git-tag-version
+cd ..
+
+# Commit version changes
+echo "📝 Committing version sync..."
+git add npx-wrapper/package.json
+git commit -m "chore: sync NPM version to $VERSION_NO_V for release
+
+- Updated package.json version to match Git tag
+- Python version will be auto-derived from Git tag via setuptools-scm
+- Maintains single source of truth versioning"
+
+# Create and push the Git tag (this triggers Python version via setuptools-scm)
+echo "🏷️  Creating Git tag $VERSION..."
+git tag -a "$VERSION" -m "Release $VERSION
+
+🎯 Single Source of Truth Versioning:
+- Git tag: $VERSION (authoritative)
+- Python version: $VERSION_NO_V (auto-derived via setuptools-scm)
+- NPM version: $VERSION_NO_V (synced in package.json)
+
+✅ All versions automatically synchronized"
+
+# Push changes and tag
+echo "📤 Pushing changes and tag..."
+git push origin main
+git push origin "$VERSION"
+
+# Create GitHub release
+echo "🎉 Creating GitHub release..."
+if command -v gh &> /dev/null; then
+    gh release create "$VERSION" --title "JustiFi MCP Server $VERSION" --generate-notes
+    echo "✅ GitHub release created: https://github.com/justifi-tech/mcp-server/releases/tag/$VERSION"
+else
+    echo "⚠️  GitHub CLI not available, please create release manually"
+fi
+
+echo ""
+echo "🎉 Release $VERSION completed successfully!"
+echo ""
+echo "📋 Version Summary:"
+echo "  Git Tag: $VERSION (single source of truth)"
+echo "  Python: $VERSION_NO_V (auto-derived via setuptools-scm)"
+echo "  NPM: $VERSION_NO_V (synced in package.json)"
+echo ""
+echo "🔗 Next steps:"
+echo "1. Verify release: https://github.com/justifi-tech/mcp-server/releases/tag/$VERSION"
+echo "2. Test Python install: pip install git+https://github.com/justifi-tech/mcp-server.git@$VERSION"
+echo "3. Test NPM install: npx @justifi/mcp-server@$VERSION_NO_V"
+echo ""
+echo "✨ All versions are now automatically synchronized!" 


### PR DESCRIPTION
## Overview

Implements a single source of truth versioning system that eliminates version mismatches permanently by using Git tags as the authoritative version source.

## Problem Solved

Previously we had version mismatches:
- pyproject.toml: `2.0.0-dev`
- npx-wrapper/package.json: `1.0.0`
- justifi_mcp/__init__.py: `2.0.0-dev`
- Git tags: `v1.0.0`

This caused confusion and installation issues for users.

## Solution

### 🎯 Single Source of Truth: Git Tags
```
Git Tag (v1.0.1) → Python Version (1.0.1) → NPM Version (1.0.1)
```

1. **Git Tag**: The authoritative version (e.g., `v1.0.1`)
2. **Python Version**: Auto-derived from Git tag via `setuptools-scm`
3. **NPM Version**: Synced to match Git tag via release script

## Changes Made

### ✅ setuptools-scm Integration
- Added setuptools-scm to pyproject.toml build requirements
- Removed hardcoded version, use `dynamic = ["version"]`
- Auto-generates `justifi_mcp/_version.py` from Git tags
- Updated `__init__.py` to import version from setuptools-scm

### ✅ Automated Release Script
- `scripts/release-automated.sh` - One command creates entire release
- Validates version format and prerequisites
- Updates NPM package.json to match Git tag
- Creates Git tag (triggers Python version via setuptools-scm)
- Creates GitHub release automatically

### ✅ Version Validation
- `scripts/check-version-sync.sh` - Validates all versions are synchronized
- Added `make version-check` target
- Can be integrated into CI to prevent version drift

### ✅ Comprehensive Documentation
- `docs/VERSIONING.md` - Complete guide to the new system
- Migration guide from old system
- Troubleshooting and best practices

## Benefits

- ✅ **Eliminates version mismatches permanently**
- ✅ **Single command releases** (`./scripts/release-automated.sh v1.0.1`)
- ✅ **Automatic Python version derivation** from Git tags
- ✅ **CI validation** prevents version drift
- ✅ **Developer experience** - no manual version updates

## Usage

### Create a Release
```bash
# One command does everything
./scripts/release-automated.sh v1.0.1
```

### Check Version Sync
```bash
make version-check
```

## Testing

- ✅ Version validation script works correctly
- ✅ All new scripts are executable
- ✅ setuptools-scm configuration is valid
- ✅ Makefile target added successfully

## Next Steps

After merging:
1. Test the automated release script with a patch version
2. Add version validation to CI workflow
3. Update RELEASING.md to reference new system

Closes #14