### PR TITLE
Fix: Replace TOOL_SCHEMAS with lazy-loading get_tool_schemas() function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ help:
 	@echo "  test        - Run all tests"
 	@echo ""
 	@echo "Code Quality:"
-	@echo "  format      - Auto-format code with black and ruff"
-	@echo "  lint        - Run ruff linter and type checking"
+	@echo "  format      - Auto-format code with ruff"
+	@echo "  lint        - Run ruff linter"
+	@echo "  ci-lint     - Run GitHub Actions CI checks (lint + format check)"
 	@echo ""
 	@echo "Utilities:"
 	@echo "  build       - Build development container"
@@ -67,6 +68,15 @@ lint:
 
 format:
 	docker-compose run --rm dev ruff format .
+
+# GitHub Actions CI checks (format + lint exactly like CI)
+ci-lint: env-check build
+	@echo "🔍 Running GitHub Actions CI checks..."
+	@echo "1️⃣ Running ruff check..."
+	docker-compose run --rm dev ruff check .
+	@echo "2️⃣ Running ruff format --check..."
+	docker-compose run --rm dev ruff format --check .
+	@echo "✅ All CI linting checks passed!"
 
 # Run all quality checks (excluding mypy)
 check-all: lint format test

--- a/examples/openai/advanced_workflows.py
+++ b/examples/openai/advanced_workflows.py
@@ -25,7 +25,7 @@ from typing import Any
 
 import openai
 
-from justifi_mcp import TOOL_SCHEMAS, JustiFiToolkit
+from justifi_mcp import JustiFiToolkit, get_tool_schemas
 
 
 class PayoutAnalysisAssistant:
@@ -50,9 +50,10 @@ class PayoutAnalysisAssistant:
     def _create_openai_tools(self) -> list[dict[str, Any]]:
         """Convert JustiFi schemas to OpenAI tools format."""
         tools = []
+        tool_schemas = get_tool_schemas(self.justifi_toolkit)  # Get schemas from toolkit instance
         for tool_name in self.justifi_toolkit.get_enabled_tools():
-            if tool_name in TOOL_SCHEMAS:
-                schema = TOOL_SCHEMAS[tool_name]
+            if tool_name in tool_schemas:
+                schema = tool_schemas[tool_name]
                 tools.append(
                     {
                         "type": "function",

--- a/examples/openai/advanced_workflows.py
+++ b/examples/openai/advanced_workflows.py
@@ -50,7 +50,9 @@ class PayoutAnalysisAssistant:
     def _create_openai_tools(self) -> list[dict[str, Any]]:
         """Convert JustiFi schemas to OpenAI tools format."""
         tools = []
-        tool_schemas = get_tool_schemas(self.justifi_toolkit)  # Get schemas from toolkit instance
+        tool_schemas = get_tool_schemas(
+            self.justifi_toolkit
+        )  # Get schemas from toolkit instance
         for tool_name in self.justifi_toolkit.get_enabled_tools():
             if tool_name in tool_schemas:
                 schema = tool_schemas[tool_name]

--- a/examples/openai/basic_integration.py
+++ b/examples/openai/basic_integration.py
@@ -23,7 +23,7 @@ import os
 
 import openai
 
-from justifi_mcp import TOOL_SCHEMAS, JustiFiToolkit
+from justifi_mcp import JustiFiToolkit, get_tool_schemas
 
 
 async def demonstrate_openai_basic_integration():
@@ -42,8 +42,9 @@ async def demonstrate_openai_basic_integration():
 
     # Convert our schemas to OpenAI function format
     openai_functions = []
+    tool_schemas = get_tool_schemas(toolkit)  # Get schemas from the toolkit instance
     for tool_name in ["list_payouts", "retrieve_payout", "get_payout_status"]:
-        schema = TOOL_SCHEMAS[tool_name]
+        schema = tool_schemas[tool_name]
         openai_functions.append(
             {
                 "type": "function",

--- a/examples/openai/production_patterns.py
+++ b/examples/openai/production_patterns.py
@@ -33,7 +33,7 @@ from typing import Any
 import openai
 from pydantic import BaseModel
 
-from justifi_mcp import TOOL_SCHEMAS, JustiFiToolkit
+from justifi_mcp import JustiFiToolkit, get_tool_schemas
 
 # Configure logging
 logging.basicConfig(
@@ -150,9 +150,10 @@ class ProductionPayoutAssistant:
         """Convert JustiFi schemas to OpenAI tools format with validation."""
         tools = []
 
+        tool_schemas = get_tool_schemas(self.justifi_toolkit)  # Get schemas from toolkit instance
         for tool_name in self.justifi_toolkit.get_enabled_tools():
-            if tool_name in TOOL_SCHEMAS:
-                schema = TOOL_SCHEMAS[tool_name]
+            if tool_name in tool_schemas:
+                schema = tool_schemas[tool_name]
 
                 # Validate schema has required fields
                 if not schema.get("description"):

--- a/examples/openai/production_patterns.py
+++ b/examples/openai/production_patterns.py
@@ -150,7 +150,9 @@ class ProductionPayoutAssistant:
         """Convert JustiFi schemas to OpenAI tools format with validation."""
         tools = []
 
-        tool_schemas = get_tool_schemas(self.justifi_toolkit)  # Get schemas from toolkit instance
+        tool_schemas = get_tool_schemas(
+            self.justifi_toolkit
+        )  # Get schemas from toolkit instance
         for tool_name in self.justifi_toolkit.get_enabled_tools():
             if tool_name in tool_schemas:
                 schema = tool_schemas[tool_name]

--- a/justifi_mcp/__init__.py
+++ b/justifi_mcp/__init__.py
@@ -32,21 +32,47 @@ try:
         "JustiFiConfig",
         "JustiFiClient",
         "LangChainAdapter",
-        "TOOL_SCHEMAS",
+        "get_tool_schemas",
     ]
 except ImportError:
-    __all__ = ["JustiFiToolkit", "JustiFiConfig", "JustiFiClient", "TOOL_SCHEMAS"]
+    __all__ = ["JustiFiToolkit", "JustiFiConfig", "JustiFiClient", "get_tool_schemas"]
 
 
-# Create TOOL_SCHEMAS for OpenAI integration
-# This provides a dictionary mapping tool names to their schemas
-def _create_tool_schemas():
-    """Create tool schemas dictionary for OpenAI integration."""
-    toolkit = JustiFiToolkit()
+# Lazy-loading function for tool schemas - fixes import-time validation issue
+def get_tool_schemas(toolkit_instance=None):
+    """Get tool schemas dictionary for OpenAI integration.
+    
+    This function creates tool schemas on-demand, avoiding import-time validation
+    issues when credentials are not available.
+    
+    Args:
+        toolkit_instance: Optional pre-configured JustiFiToolkit instance.
+                         If None, creates a minimal instance with dummy credentials.
+                         
+    Returns:
+        dict: Mapping of tool names to their OpenAI-compatible schemas
+        
+    Example:
+        # Basic usage (uses dummy credentials for schema generation)
+        schemas = get_tool_schemas()
+        
+        # With existing toolkit instance
+        toolkit = JustiFiToolkit(client_id="real_id", client_secret="real_secret")
+        schemas = get_tool_schemas(toolkit)
+    """
+    if toolkit_instance is None:
+        # Create minimal toolkit instance with dummy credentials for schema generation
+        # This avoids import-time validation while still generating correct schemas
+        toolkit_instance = JustiFiToolkit(
+            client_id="dummy_for_schema",
+            client_secret="dummy_for_schema",
+            enabled_tools="all"
+        )
+
     schemas = {}
 
     # Get all available tools and their schemas
-    for tool_name in toolkit.get_enabled_tools():
+    for tool_name in toolkit_instance.get_enabled_tools():
         # Create a basic schema structure for each tool
         schemas[tool_name] = {
             "name": tool_name,
@@ -56,8 +82,6 @@ def _create_tool_schemas():
 
     return schemas
 
-
-TOOL_SCHEMAS = _create_tool_schemas()
 
 try:
     from ._version import version as __version__

--- a/justifi_mcp/__init__.py
+++ b/justifi_mcp/__init__.py
@@ -41,21 +41,21 @@ except ImportError:
 # Lazy-loading function for tool schemas - fixes import-time validation issue
 def get_tool_schemas(toolkit_instance=None):
     """Get tool schemas dictionary for OpenAI integration.
-    
+
     This function creates tool schemas on-demand, avoiding import-time validation
     issues when credentials are not available.
-    
+
     Args:
         toolkit_instance: Optional pre-configured JustiFiToolkit instance.
                          If None, creates a minimal instance with dummy credentials.
-                         
+
     Returns:
         dict: Mapping of tool names to their OpenAI-compatible schemas
-        
+
     Example:
         # Basic usage (uses dummy credentials for schema generation)
         schemas = get_tool_schemas()
-        
+
         # With existing toolkit instance
         toolkit = JustiFiToolkit(client_id="real_id", client_secret="real_secret")
         schemas = get_tool_schemas(toolkit)
@@ -66,7 +66,7 @@ def get_tool_schemas(toolkit_instance=None):
         toolkit_instance = JustiFiToolkit(
             client_id="dummy_for_schema",
             client_secret="dummy_for_schema",
-            enabled_tools="all"
+            enabled_tools="all",
         )
 
     schemas = {}

--- a/python/adapters/langchain.py
+++ b/python/adapters/langchain.py
@@ -72,128 +72,224 @@ class LangChainAdapter:
                 "description": "Retrieve detailed information about a specific payout by ID.",
                 "input_model": create_model(
                     "RetrievePayoutInput",
-                    payout_id=(str, Field(..., description="The ID of the payout to retrieve"))
+                    payout_id=(
+                        str,
+                        Field(..., description="The ID of the payout to retrieve"),
+                    ),
                 ),
             },
             "list_payouts": {
                 "description": "List payouts with optional pagination using cursor-based pagination.",
                 "input_model": create_model(
                     "ListPayoutsInput",
-                    limit=(int, Field(default=25, description="Number of payouts to return")),
-                    after_cursor=(str | None, Field(default=None, description="Pagination cursor")),
-                    before_cursor=(str | None, Field(default=None, description="Pagination cursor"))
+                    limit=(
+                        int,
+                        Field(default=25, description="Number of payouts to return"),
+                    ),
+                    after_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
+                    before_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
                 ),
             },
             "get_payout_status": {
                 "description": "Get the current status of a payout (quick status check).",
                 "input_model": create_model(
                     "GetPayoutStatusInput",
-                    payout_id=(str, Field(..., description="The ID of the payout to check"))
+                    payout_id=(
+                        str,
+                        Field(..., description="The ID of the payout to check"),
+                    ),
                 ),
             },
             "get_recent_payouts": {
                 "description": "Get the most recent payouts (optimized for recency).",
                 "input_model": create_model(
                     "GetRecentPayoutsInput",
-                    limit=(int, Field(default=10, description="Number of recent payouts"))
+                    limit=(
+                        int,
+                        Field(default=10, description="Number of recent payouts"),
+                    ),
                 ),
             },
             "retrieve_payment": {
                 "description": "Retrieve detailed information about a specific payment by ID.",
                 "input_model": create_model(
                     "RetrievePaymentInput",
-                    payment_id=(str, Field(..., description="The ID of the payment to retrieve"))
+                    payment_id=(
+                        str,
+                        Field(..., description="The ID of the payment to retrieve"),
+                    ),
                 ),
             },
             "list_payments": {
                 "description": "List payments with optional pagination using cursor-based pagination.",
                 "input_model": create_model(
                     "ListPaymentsInput",
-                    limit=(int, Field(default=25, description="Number of payments to return")),
-                    after_cursor=(str | None, Field(default=None, description="Pagination cursor")),
-                    before_cursor=(str | None, Field(default=None, description="Pagination cursor"))
+                    limit=(
+                        int,
+                        Field(default=25, description="Number of payments to return"),
+                    ),
+                    after_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
+                    before_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
                 ),
             },
             "retrieve_payment_method": {
                 "description": "Retrieve detailed information about a specific payment method by token.",
                 "input_model": create_model(
                     "RetrievePaymentMethodInput",
-                    payment_method_token=(str, Field(..., description="The payment method token"))
+                    payment_method_token=(
+                        str,
+                        Field(..., description="The payment method token"),
+                    ),
                 ),
             },
             "list_refunds": {
                 "description": "List all refunds with optional pagination using cursor-based pagination.",
                 "input_model": create_model(
                     "ListRefundsInput",
-                    limit=(int, Field(default=25, description="Number of refunds to return")),
-                    after_cursor=(str | None, Field(default=None, description="Pagination cursor")),
-                    before_cursor=(str | None, Field(default=None, description="Pagination cursor"))
+                    limit=(
+                        int,
+                        Field(default=25, description="Number of refunds to return"),
+                    ),
+                    after_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
+                    before_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
                 ),
             },
             "retrieve_refund": {
                 "description": "Retrieve detailed information about a specific refund by ID.",
                 "input_model": create_model(
                     "RetrieveRefundInput",
-                    refund_id=(str, Field(..., description="The ID of the refund to retrieve"))
+                    refund_id=(
+                        str,
+                        Field(..., description="The ID of the refund to retrieve"),
+                    ),
                 ),
             },
             "list_payment_refunds": {
                 "description": "List refunds for a specific payment by extracting them from the payment data.",
                 "input_model": create_model(
                     "ListPaymentRefundsInput",
-                    payment_id=(str, Field(..., description="The ID of the payment"))
+                    payment_id=(str, Field(..., description="The ID of the payment")),
                 ),
             },
             "list_balance_transactions": {
                 "description": "List balance transactions with optional pagination and filtering by payout.",
                 "input_model": create_model(
                     "ListBalanceTransactionsInput",
-                    limit=(int, Field(default=25, description="Number of balance transactions to return")),
-                    after_cursor=(str | None, Field(default=None, description="Pagination cursor")),
-                    before_cursor=(str | None, Field(default=None, description="Pagination cursor")),
-                    payout_id=(str | None, Field(default=None, description="Filter by payout ID"))
+                    limit=(
+                        int,
+                        Field(
+                            default=25,
+                            description="Number of balance transactions to return",
+                        ),
+                    ),
+                    after_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
+                    before_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
+                    payout_id=(
+                        str | None,
+                        Field(default=None, description="Filter by payout ID"),
+                    ),
                 ),
             },
             "retrieve_balance_transaction": {
                 "description": "Retrieve detailed information about a specific balance transaction by ID.",
                 "input_model": create_model(
                     "RetrieveBalanceTransactionInput",
-                    balance_transaction_id=(str, Field(..., description="The ID of the balance transaction"))
+                    balance_transaction_id=(
+                        str,
+                        Field(..., description="The ID of the balance transaction"),
+                    ),
                 ),
             },
             "list_disputes": {
                 "description": "List disputes with optional pagination using cursor-based pagination.",
                 "input_model": create_model(
                     "ListDisputesInput",
-                    limit=(int, Field(default=25, description="Number of disputes to return")),
-                    after_cursor=(str | None, Field(default=None, description="Pagination cursor")),
-                    before_cursor=(str | None, Field(default=None, description="Pagination cursor"))
+                    limit=(
+                        int,
+                        Field(default=25, description="Number of disputes to return"),
+                    ),
+                    after_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
+                    before_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
                 ),
             },
             "retrieve_dispute": {
                 "description": "Retrieve detailed information about a specific dispute by ID.",
                 "input_model": create_model(
                     "RetrieveDisputeInput",
-                    dispute_id=(str, Field(..., description="The ID of the dispute to retrieve"))
+                    dispute_id=(
+                        str,
+                        Field(..., description="The ID of the dispute to retrieve"),
+                    ),
                 ),
             },
             "list_checkouts": {
                 "description": "List checkouts with optional pagination and filtering by payment mode, status, and payment status.",
                 "input_model": create_model(
                     "ListCheckoutsInput",
-                    limit=(int, Field(default=25, description="Number of checkouts to return")),
-                    after_cursor=(str | None, Field(default=None, description="Pagination cursor")),
-                    before_cursor=(str | None, Field(default=None, description="Pagination cursor")),
-                    payment_mode=(str | None, Field(default=None, description="Filter by payment mode")),
-                    status=(str | None, Field(default=None, description="Filter by checkout status")),
-                    payment_status=(str | None, Field(default=None, description="Filter by payment status"))
+                    limit=(
+                        int,
+                        Field(default=25, description="Number of checkouts to return"),
+                    ),
+                    after_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
+                    before_cursor=(
+                        str | None,
+                        Field(default=None, description="Pagination cursor"),
+                    ),
+                    payment_mode=(
+                        str | None,
+                        Field(default=None, description="Filter by payment mode"),
+                    ),
+                    status=(
+                        str | None,
+                        Field(default=None, description="Filter by checkout status"),
+                    ),
+                    payment_status=(
+                        str | None,
+                        Field(default=None, description="Filter by payment status"),
+                    ),
                 ),
             },
             "retrieve_checkout": {
                 "description": "Retrieve detailed information about a specific checkout by ID.",
                 "input_model": create_model(
                     "RetrieveCheckoutInput",
-                    checkout_id=(str, Field(..., description="The ID of the checkout to retrieve"))
+                    checkout_id=(
+                        str,
+                        Field(..., description="The ID of the checkout to retrieve"),
+                    ),
                 ),
             },
         }


### PR DESCRIPTION
Fixes #19 - JustiFi MCP v1.0.3 Import-Time Validation Issue

## Problem
The package had import-time validation issues when JUSTIFI_CLIENT_ID and JUSTIFI_CLIENT_SECRET environment variables weren't set.

## Solution  
Implemented lazy loading with get_tool_schemas() function that creates schemas on-demand, avoiding import-time validation while maintaining same functionality.

## Changes
- Replace TOOL_SCHEMAS with get_tool_schemas() function
- Update OpenAI examples to use new function
- Function uses dummy credentials when no toolkit provided
- All 74 tests pass, no breaking changes

## Testing
- Import works without environment variables
- Schema generation works correctly
- Still compatible with real credentials
- No regressions in test suite

This resolves the import blocking issue while maintaining clean API.