### PR TITLE
Address issue 28 with minimal changes

### DIFF
--- a/examples/langchain/README.md
+++ b/examples/langchain/README.md
@@ -72,7 +72,7 @@ python examples/langchain/production_patterns.py
 The core pattern for LangChain integration:
 
 ```python
-from justifi_mcp import JustiFiToolkit
+from python import JustiFiToolkit
 from langchain.agents import AgentExecutor, create_openai_tools_agent
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_openai import ChatOpenAI

--- a/examples/openai/README.md
+++ b/examples/openai/README.md
@@ -67,8 +67,7 @@ python examples/openai/production_patterns.py
 The core pattern for OpenAI integration:
 
 ```python
-from justifi_mcp import JustiFiToolkit
-from justifi_mcp.tools import TOOL_SCHEMAS
+from python import JustiFiToolkit, get_tool_schemas
 import openai
 
 # 1. Initialize toolkit


### PR DESCRIPTION
Update example READMEs to use direct imports from the `python` module, resolving import inconsistencies after `justifi_mcp` wrapper removal.
Closes #28 
