### PR TITLE
Fix release workflow: reorder version sync validation after NPM update

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -49,12 +49,6 @@ jobs:
         run: |
           pytest tests/ -v
       
-      - name: Validate version synchronization
-        run: |
-          ./scripts/check-version-sync.sh
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      
       - name: Update NPM package.json
         if: env.NPM_TOKEN != ''
         run: |
@@ -62,6 +56,12 @@ jobs:
           npm version ${{ steps.version.outputs.version_no_v }} --no-git-tag-version
           cd ..
           echo "✅ NPM version updated to ${{ steps.version.outputs.version_no_v }}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      
+      - name: Validate version synchronization
+        run: |
+          ./scripts/check-version-sync.sh
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       


### PR DESCRIPTION
## Problem

The automated release workflow is failing on the 'Validate version synchronization' step because it's checking version consistency before updating the NPM package.json version.

## Root Cause

In , the workflow steps were in the wrong order:

1. ✅ Run tests
2. ❌ **Validate version synchronization** (fails here - checks old NPM version)
3. ⏭️ Update NPM package.json (would fix the version)
4. ⏭️ Commit version sync

## Current Behavior

- Git tag: `v1.0.7` (latest)
- NPM version: `1.0.0` (outdated in package.json)
- Validation script expects NPM version to match Git tag
- Since `1.0.0 ≠ 1.0.7`, validation fails with exit code 1

## Solution

Reordered the workflow steps:

1. ✅ Run tests
2. ✅ **Update NPM package.json** (now runs first)
3. ✅ **Validate version synchronization** (now runs after update)
4. ✅ Commit version sync

## Changes

- Moved 'Update NPM package.json' step before 'Validate version synchronization' step
- No logic changes, just reordering of existing steps
- Ensures NPM version is updated before validation checks run

## Testing

- Verified workflow step order is now correct
- Logic flow: Update → Validate → Commit → Release
- This will allow validation to pass since both Git tag and NPM version will match

Closes #41