### PR TITLE
fix: Add missing build step to NPM package publishing

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -58,6 +58,15 @@ jobs:
         env:
           JUSTIFI_SUPPORT_NPM_TOKEN: ${{ secrets.JUSTIFI_SUPPORT_NPM_TOKEN }}
       
+      - name: Build NPM package
+        if: env.JUSTIFI_SUPPORT_NPM_TOKEN != ''
+        run: |
+          cd npx-wrapper
+          node build.js
+          echo "✅ NPM package built successfully"
+        env:
+          JUSTIFI_SUPPORT_NPM_TOKEN: ${{ secrets.JUSTIFI_SUPPORT_NPM_TOKEN }}
+      
       - name: Create GitHub Release
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## 🚨 Critical Bug Fix - Missing NPM Package Files

### Problem
The NPM package  was missing essential server files, causing this error:
```
Error: Server script not found: /Users/user/.npm/_npx/.../main.py
```

### Root Cause
The GitHub Actions workflow was publishing NPM packages **without building them first**:
1. ✅ Updates package.json version
2. ❌ **MISSING**: Runs `node build.js` to copy server files  
3. ✅ Publishes to NPM

This meant only the files already in `npx-wrapper/` were published, missing:
- `main.py` (entry point)
- `python/` (MCP tools)
- `modelcontextprotocol/` (server implementation)

### Solution
Added the missing build step to `.github/workflows/automated-release.yml`:

```yaml
- name: Build NPM package
  if: env.JUSTIFI_SUPPORT_NPM_TOKEN != ''
  run: |
    cd npx-wrapper
    node build.js
    echo "✅ NPM package built successfully"
```

### Testing
- ✅ Local build works: `node build.js` copies all files correctly
- ✅ Local test passes: `npx ./justifi-mcp-server-1.0.20.tgz --version`
- ✅ Package now includes 25 files (vs ~6 before)

### Impact
- **Fixes**: NPM package missing server files 
- **Enables**: Proper `npx @justifi/mcp-server` usage
- **Prevents**: Future releases with incomplete packages

**Next release (v1.0.21) will include all necessary files.** 🎯

Fixes: #57 