### PR TITLE
refactor: improve LangChain adapter to be fully async (fixes #62)

### DIFF
--- a/examples/langchain/README.md
+++ b/examples/langchain/README.md
@@ -6,7 +6,7 @@ This directory contains comprehensive examples demonstrating how to integrate Ju
 
 LangChain requires specific tool wrapping and schema formats. Our dedicated adapter provides:
 - **StructuredTool integration** with Pydantic validation
-- **Async/sync compatibility** for different LangChain patterns
+- **Async-only execution** for optimal performance
 - **Error handling** with LangChain-specific error types
 - **Memory integration** for stateful conversations
 
@@ -16,7 +16,7 @@ LangChain requires specific tool wrapping and schema formats. Our dedicated adap
 - **Purpose**: Fundamental LangChain agent integration with JustiFi tools
 - **Features**:
   - OpenAI Tools Agent with JustiFi capabilities
-  - Direct tool usage (sync and async)
+  - Direct async tool usage
   - Error handling demonstrations
   - Agent executor configuration
 - **Best for**: Getting started, understanding LangChain basics

--- a/examples/langchain/basic_integration.py
+++ b/examples/langchain/basic_integration.py
@@ -139,11 +139,7 @@ async def demonstrate_direct_tool_usage():
         print("🔧 Calling list_payouts tool directly...")
 
         try:
-            # Call tool directly (sync version)
-            result = list_payouts_tool.func(limit=5)
-            print(f"📊 Direct tool result:\n{result}\n")
-
-            # Call tool async version
+            # Call tool asynchronously (async-only in JustiFi adapter)
             print("🔧 Calling list_payouts tool asynchronously...")
             async_result = await list_payouts_tool.arun({"limit": 3})
             print(f"📊 Async tool result:\n{async_result}\n")
@@ -206,7 +202,7 @@ if __name__ == "__main__":
 
         print("\n🎯 Key LangChain Integration Features:")
         print("   • Seamless integration with LangChain agents")
-        print("   • Both sync and async tool execution")
+        print("   • Async-only tool execution for optimal performance")
         print("   • Structured tool schemas with Pydantic validation")
         print("   • Comprehensive error handling and recovery")
         print("   • Direct tool access for custom workflows")


### PR DESCRIPTION
Refactors the LangChain adapter to be fully async, removing complex sync wrapper functions and improving performance.

## Changes
- Remove complex sync wrapper function (~23 lines eliminated)
- Rename async_wrapper to execute_tool_async for clarity
- Update StructuredTool creation to use only coroutine parameter
- Update examples and documentation to reflect async-only usage
- Maintain backward compatibility for existing async patterns

## Benefits
- Better performance (no thread pool overhead)
- Cleaner architecture (single async execution path)
- Future-proof (aligns with LangChain's async-first direction)
- Simplified maintenance and debugging

Closes #62

Generated with [Claude Code](https://claude.ai/code)