### PR TITLE
feat: add sub account routes as available MCP tools (fixes #65)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ This is a **JustiFi MCP (Model Context Protocol) server** designed for AI-assist
 - **Automatic sync**: CI validates synchronization on all PRs
 - **To update NPM README**: `cp README.md npx-wrapper/README.md`
 
-**Rationale**: Prevents documentation drift between main project and NPM package, ensuring NPM users see complete 18-tool documentation instead of outdated 10-tool subset.
+**Rationale**: Prevents documentation drift between main project and NPM package, ensuring NPM users see complete 20-tool documentation instead of outdated subset.
 
 ## Package Management
 - **ALWAYS use `uv` instead of `pip`**

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ This MCP server provides complete payment management capabilities across multipl
 ### Payment Method Tools
 - `retrieve_payment_method` - Get payment method by token
 
+### Sub Account Tools
+- `list_sub_accounts` - List sub accounts with status filtering
+- `get_sub_account` - Get sub account details by ID
+- `get_sub_account_payout_account` - Get sub account payout account
+- `get_sub_account_settings` - Get sub account settings
+
 
 
 ## 🚀 Quick Start

--- a/docs/endpoint-inventory.md
+++ b/docs/endpoint-inventory.md
@@ -1,8 +1,8 @@
 # JustiFi API Endpoint Inventory
 Generated from OpenAPI spec: 2025-01-25
 
-## Current Implementation Status (v1.3)
-✅ **16 tools implemented and tested** - All core functionality plus refunds, balance transactions, disputes, and checkouts
+## Current Implementation Status (v1.4)
+✅ **20 tools implemented and tested** - All core functionality plus refunds, balance transactions, disputes, checkouts, and sub accounts
 
 | Endpoint | Method | Description | Tool Name | Status |
 |----------|--------|-------------|-----------|--------|
@@ -22,6 +22,10 @@ Generated from OpenAPI spec: 2025-01-25
 | `/disputes/{id}` | GET | Retrieve dispute details | `retrieve_dispute` | ✅ IMPLEMENTED |
 | `/checkouts` | GET | List checkouts with pagination | `list_checkouts` | ✅ IMPLEMENTED |
 | `/checkouts/{id}` | GET | Retrieve checkout details | `retrieve_checkout` | ✅ IMPLEMENTED |
+| `/sub_accounts` | GET | List sub accounts with filtering | `list_sub_accounts` | ✅ IMPLEMENTED |
+| `/sub_accounts/{id}` | GET | Retrieve sub account details | `get_sub_account` | ✅ IMPLEMENTED |
+| `/sub_accounts/{id}/payout_account` | GET | Get sub account payout account | `get_sub_account_payout_account` | ✅ IMPLEMENTED |
+| `/sub_accounts/{id}/settings` | GET | Get sub account settings | `get_sub_account_settings` | ✅ IMPLEMENTED |
 
 
 

--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -324,3 +324,72 @@ def register_tools(mcp: FastMCP, client: JustiFiClient) -> None:
         from python.tools.checkouts import retrieve_checkout as _retrieve_checkout
 
         return await _retrieve_checkout(client, checkout_id)
+
+    # Sub Account tools
+    @mcp.tool
+    async def list_sub_accounts(
+        status: str = None,
+        limit: int = 25,
+        after_cursor: str = None,
+        before_cursor: str = None,
+    ) -> dict[str, Any]:
+        """List sub accounts with optional status filtering and pagination.
+
+        Args:
+            status: Optional status filter - one of: created, submitted, information_needed, rejected, approved, enabled, disabled, archived
+            limit: Number of sub accounts to return (1-100, default: 25)
+            after_cursor: Cursor for pagination - returns results after this cursor
+            before_cursor: Cursor for pagination - returns results before this cursor
+
+        Returns:
+            Paginated list of sub accounts with page_info for navigation
+        """
+        from python.tools.sub_accounts import list_sub_accounts as _list_sub_accounts
+
+        return await _list_sub_accounts(client, status, limit, after_cursor, before_cursor)
+
+    @mcp.tool
+    async def get_sub_account(sub_account_id: str) -> dict[str, Any]:
+        """Get detailed information about a specific sub account by ID.
+
+        Args:
+            sub_account_id: The unique identifier for the sub account (e.g., 'acc_ABC123XYZ')
+
+        Returns:
+            Sub account object with ID, name, status, and other details
+        """
+        from python.tools.sub_accounts import get_sub_account as _get_sub_account
+
+        return await _get_sub_account(client, sub_account_id)
+
+    @mcp.tool
+    async def get_sub_account_payout_account(sub_account_id: str) -> dict[str, Any]:
+        """Get information about the currently active payout bank account of a sub account.
+
+        Args:
+            sub_account_id: The unique identifier for the sub account (e.g., 'acc_ABC123XYZ')
+
+        Returns:
+            Payout bank account object with account details
+        """
+        from python.tools.sub_accounts import (
+            get_sub_account_payout_account as _get_sub_account_payout_account,
+        )
+
+        return await _get_sub_account_payout_account(client, sub_account_id)
+
+    @mcp.tool
+    async def get_sub_account_settings(sub_account_id: str) -> dict[str, Any]:
+        """Get information about sub account settings.
+
+        Args:
+            sub_account_id: The unique identifier for the sub account (e.g., 'acc_ABC123XYZ')
+
+        Returns:
+            Sub account settings object
+        """
+        from python.tools.sub_accounts import (
+            get_sub_account_settings as _get_sub_account_settings,
+        )
+
+        return await _get_sub_account_settings(client, sub_account_id)

--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -346,7 +346,9 @@ def register_tools(mcp: FastMCP, client: JustiFiClient) -> None:
         """
         from python.tools.sub_accounts import list_sub_accounts as _list_sub_accounts
 
-        return await _list_sub_accounts(client, status, limit, after_cursor, before_cursor)
+        return await _list_sub_accounts(
+            client, status, limit, after_cursor, before_cursor
+        )
 
     @mcp.tool
     async def get_sub_account(sub_account_id: str) -> dict[str, Any]:

--- a/npx-wrapper/README.md
+++ b/npx-wrapper/README.md
@@ -84,6 +84,12 @@ This MCP server provides complete payment management capabilities across multipl
 ### Payment Method Tools
 - `retrieve_payment_method` - Get payment method by token
 
+### Sub Account Tools
+- `list_sub_accounts` - List sub accounts with status filtering
+- `get_sub_account` - Get sub account details by ID
+- `get_sub_account_payout_account` - Get sub account payout account
+- `get_sub_account_settings` - Get sub account settings
+
 
 
 ## 🚀 Quick Start

--- a/python/toolkit.py
+++ b/python/toolkit.py
@@ -31,6 +31,10 @@ _TOOL_NAMES = [
     "list_payment_refunds",
     "list_refunds",
     "retrieve_refund",
+    "get_sub_account",
+    "get_sub_account_payout_account",
+    "get_sub_account_settings",
+    "list_sub_accounts",
 ]
 
 

--- a/python/tools/__init__.py
+++ b/python/tools/__init__.py
@@ -13,6 +13,12 @@ from .payouts import (
     retrieve_payout,
 )
 from .refunds import list_payment_refunds, list_refunds, retrieve_refund
+from .sub_accounts import (
+    get_sub_account,
+    get_sub_account_payout_account,
+    get_sub_account_settings,
+    list_sub_accounts,
+)
 
 __all__ = [
     "list_balance_transactions",
@@ -31,4 +37,8 @@ __all__ = [
     "list_payment_refunds",
     "list_refunds",
     "retrieve_refund",
+    "get_sub_account",
+    "get_sub_account_payout_account",
+    "get_sub_account_settings",
+    "list_sub_accounts",
 ]

--- a/python/tools/sub_accounts.py
+++ b/python/tools/sub_accounts.py
@@ -1,0 +1,232 @@
+"""
+JustiFi Sub Account Tools
+
+Core sub account operations for retrieving and listing sub accounts,
+their payout accounts, and settings.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..core import JustiFiClient
+from .base import ToolError, ValidationError
+
+
+async def list_sub_accounts(
+    client: JustiFiClient,
+    status: str | None = None,
+    limit: int = 25,
+    after_cursor: str | None = None,
+    before_cursor: str | None = None,
+) -> dict[str, Any]:
+    """List sub accounts with optional status filtering and pagination.
+
+    Args:
+        client: JustiFi API client
+        status: Optional status filter - one of: created, submitted, information_needed,
+               rejected, approved, enabled, disabled, archived
+        limit: Number of sub accounts to return (1-100, default: 25)
+        after_cursor: Cursor for pagination - returns results after this cursor
+        before_cursor: Cursor for pagination - returns results before this cursor
+
+    Returns:
+        Paginated list of sub accounts with page_info for navigation
+
+    Raises:
+        ValidationError: If parameters are invalid
+        ToolError: If sub account listing fails
+    """
+    # Validate limit
+    if not isinstance(limit, int) or limit < 1 or limit > 100:
+        raise ValidationError(
+            "limit must be an integer between 1 and 100", field="limit", value=limit
+        )
+
+    # Validate status if provided
+    valid_statuses = {
+        "created", "submitted", "information_needed", "rejected",
+        "approved", "enabled", "disabled", "archived"
+    }
+    if status is not None:
+        if not isinstance(status, str):
+            raise ValidationError(
+                "status must be a string if provided", field="status", value=status
+            )
+        if status not in valid_statuses:
+            raise ValidationError(
+                f"status must be one of: {', '.join(sorted(valid_statuses))}",
+                field="status",
+                value=status,
+            )
+
+    # Validate cursors (if provided)
+    if after_cursor is not None and not isinstance(after_cursor, str):
+        raise ValidationError(
+            "after_cursor must be a string if provided",
+            field="after_cursor",
+            value=after_cursor,
+        )
+
+    if before_cursor is not None and not isinstance(before_cursor, str):
+        raise ValidationError(
+            "before_cursor must be a string if provided",
+            field="before_cursor",
+            value=before_cursor,
+        )
+
+    # Cannot use both cursors at the same time
+    if after_cursor and before_cursor:
+        raise ValidationError(
+            "Cannot specify both after_cursor and before_cursor",
+            field="cursors",
+            value={"after_cursor": after_cursor, "before_cursor": before_cursor},
+        )
+
+    try:
+        # Build query parameters
+        params: dict[str, Any] = {"limit": limit}
+
+        if status:
+            params["status"] = status
+        if after_cursor:
+            params["after_cursor"] = after_cursor
+        if before_cursor:
+            params["before_cursor"] = before_cursor
+
+        # Call JustiFi API to list sub accounts
+        result = await client.request("GET", "/v1/sub_accounts", params=params)
+        return result
+
+    except Exception as e:
+        raise ToolError(
+            f"Failed to list sub accounts: {str(e)}", error_type="SubAccountListError"
+        ) from e
+
+
+async def get_sub_account(client: JustiFiClient, sub_account_id: str) -> dict[str, Any]:
+    """Get detailed information about a specific sub account by ID.
+
+    Args:
+        client: JustiFi API client
+        sub_account_id: The unique identifier for the sub account (e.g., 'acc_ABC123XYZ')
+
+    Returns:
+        Sub account object with ID, name, status, and other details
+
+    Raises:
+        ValidationError: If sub_account_id is invalid
+        ToolError: If sub account retrieval fails
+    """
+    if sub_account_id is None or not isinstance(sub_account_id, str):
+        raise ValidationError(
+            "sub_account_id is required and must be a non-empty string",
+            field="sub_account_id",
+            value=sub_account_id,
+        )
+
+    if not sub_account_id.strip():
+        raise ValidationError(
+            "sub_account_id cannot be empty or whitespace",
+            field="sub_account_id",
+            value=sub_account_id,
+        )
+
+    try:
+        # Call JustiFi API to retrieve sub account
+        result = await client.request("GET", f"/v1/sub_accounts/{sub_account_id}")
+        return result
+
+    except Exception as e:
+        raise ToolError(
+            f"Failed to retrieve sub account {sub_account_id}: {str(e)}",
+            error_type="SubAccountRetrievalError",
+        ) from e
+
+
+async def get_sub_account_payout_account(
+    client: JustiFiClient, sub_account_id: str
+) -> dict[str, Any]:
+    """Get information about the currently active payout bank account of a sub account.
+
+    Args:
+        client: JustiFi API client
+        sub_account_id: The unique identifier for the sub account (e.g., 'acc_ABC123XYZ')
+
+    Returns:
+        Payout bank account object with account details
+
+    Raises:
+        ValidationError: If sub_account_id is invalid
+        ToolError: If payout account retrieval fails
+    """
+    if sub_account_id is None or not isinstance(sub_account_id, str):
+        raise ValidationError(
+            "sub_account_id is required and must be a non-empty string",
+            field="sub_account_id",
+            value=sub_account_id,
+        )
+
+    if not sub_account_id.strip():
+        raise ValidationError(
+            "sub_account_id cannot be empty or whitespace",
+            field="sub_account_id",
+            value=sub_account_id,
+        )
+
+    try:
+        # Call JustiFi API to retrieve sub account payout account
+        result = await client.request(
+            "GET", f"/v1/sub_accounts/{sub_account_id}/payout_account"
+        )
+        return result
+
+    except Exception as e:
+        raise ToolError(
+            f"Failed to retrieve payout account for sub account {sub_account_id}: {str(e)}",
+            error_type="SubAccountPayoutAccountRetrievalError",
+        ) from e
+
+
+async def get_sub_account_settings(
+    client: JustiFiClient, sub_account_id: str
+) -> dict[str, Any]:
+    """Get information about sub account settings.
+
+    Args:
+        client: JustiFi API client
+        sub_account_id: The unique identifier for the sub account (e.g., 'acc_ABC123XYZ')
+
+    Returns:
+        Sub account settings object
+
+    Raises:
+        ValidationError: If sub_account_id is invalid
+        ToolError: If sub account settings retrieval fails
+    """
+    if sub_account_id is None or not isinstance(sub_account_id, str):
+        raise ValidationError(
+            "sub_account_id is required and must be a non-empty string",
+            field="sub_account_id",
+            value=sub_account_id,
+        )
+
+    if not sub_account_id.strip():
+        raise ValidationError(
+            "sub_account_id cannot be empty or whitespace",
+            field="sub_account_id",
+            value=sub_account_id,
+        )
+
+    try:
+        # Call JustiFi API to retrieve sub account settings
+        result = await client.request(
+            "GET", f"/v1/sub_accounts/{sub_account_id}/settings"
+        )
+        return result
+
+    except Exception as e:
+        raise ToolError(
+            f"Failed to retrieve settings for sub account {sub_account_id}: {str(e)}",
+            error_type="SubAccountSettingsRetrievalError",
+        ) from e

--- a/python/tools/sub_accounts.py
+++ b/python/tools/sub_accounts.py
@@ -45,8 +45,14 @@ async def list_sub_accounts(
 
     # Validate status if provided
     valid_statuses = {
-        "created", "submitted", "information_needed", "rejected",
-        "approved", "enabled", "disabled", "archived"
+        "created",
+        "submitted",
+        "information_needed",
+        "rejected",
+        "approved",
+        "enabled",
+        "disabled",
+        "archived",
     }
     if status is not None:
         if not isinstance(status, str):

--- a/tests/test_sub_account_tools.py
+++ b/tests/test_sub_account_tools.py
@@ -198,7 +198,9 @@ class TestGetSubAccount:
             (None, "sub_account_id is required and must be a non-empty string"),
         ],
     )
-    async def test_get_sub_account_invalid_id(self, client, sub_account_id, expected_error):
+    async def test_get_sub_account_invalid_id(
+        self, client, sub_account_id, expected_error
+    ):
         """Test get_sub_account with invalid IDs."""
         with pytest.raises(ValidationError) as exc_info:
             await get_sub_account(client, sub_account_id)
@@ -247,7 +249,9 @@ class TestGetSubAccountPayoutAccount:
             (None, "sub_account_id is required and must be a non-empty string"),
         ],
     )
-    async def test_get_sub_account_payout_account_invalid_id(self, client, sub_account_id, expected_error):
+    async def test_get_sub_account_payout_account_invalid_id(
+        self, client, sub_account_id, expected_error
+    ):
         """Test get_sub_account_payout_account with invalid IDs."""
         with pytest.raises(ValidationError) as exc_info:
             await get_sub_account_payout_account(client, sub_account_id)
@@ -299,7 +303,9 @@ class TestGetSubAccountSettings:
             (None, "sub_account_id is required and must be a non-empty string"),
         ],
     )
-    async def test_get_sub_account_settings_invalid_id(self, client, sub_account_id, expected_error):
+    async def test_get_sub_account_settings_invalid_id(
+        self, client, sub_account_id, expected_error
+    ):
         """Test get_sub_account_settings with invalid IDs."""
         with pytest.raises(ValidationError) as exc_info:
             await get_sub_account_settings(client, sub_account_id)

--- a/tests/test_sub_account_tools.py
+++ b/tests/test_sub_account_tools.py
@@ -1,0 +1,312 @@
+"""Tests for sub account tools."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+import respx
+from httpx import Response
+
+from python.core import JustiFiClient
+from python.tools.base import ToolError, ValidationError
+from python.tools.sub_accounts import (
+    get_sub_account,
+    get_sub_account_payout_account,
+    get_sub_account_settings,
+    list_sub_accounts,
+)
+
+
+@pytest.fixture
+def client():
+    """Create a test JustiFi client."""
+    client = JustiFiClient(client_id="test_id", client_secret="test_secret")
+    client.get_access_token = AsyncMock(return_value="test_token")
+    return client
+
+
+@pytest.fixture
+def mock_sub_account():
+    """Mock sub account data."""
+    return {
+        "id": "acc_test123",
+        "name": "Test Sub Account",
+        "account_type": "test",
+        "status": "enabled",
+        "currency": "usd",
+        "platform_account_id": "pla_test456",
+        "payout_account_id": "pba_test789",
+        "business_id": "biz_test101",
+        "application_fee_rates": []
+    }
+
+
+@pytest.fixture
+def mock_payout_account():
+    """Mock payout account data."""
+    return {
+        "id": "pba_test789",
+        "account_type": "bank",
+        "routing_number": "123456789",
+        "account_number_last4": "1234",
+        "status": "active"
+    }
+
+
+@pytest.fixture
+def mock_sub_account_settings():
+    """Mock sub account settings data."""
+    return {
+        "id": "acc_test123",
+        "settings": {
+            "payment_notifications": True,
+            "dispute_notifications": True,
+            "payout_notifications": False
+        }
+    }
+
+
+@pytest.mark.asyncio
+class TestListSubAccounts:
+    """Test list_sub_accounts function."""
+
+    async def test_list_sub_accounts_success(self, client, mock_sub_account):
+        """Test successful sub accounts listing."""
+        expected_response = {
+            "data": [mock_sub_account],
+            "page_info": {
+                "has_next": False,
+                "has_previous": False,
+                "start_cursor": "start123",
+                "end_cursor": "end123"
+            }
+        }
+
+        with respx.mock:
+            respx.get("https://api.justifi.ai/v1/sub_accounts").mock(
+                return_value=Response(200, json=expected_response)
+            )
+
+            result = await list_sub_accounts(client)
+            assert result == expected_response
+
+    async def test_list_sub_accounts_with_status_filter(self, client, mock_sub_account):
+        """Test listing sub accounts with status filter."""
+        expected_response = {
+            "data": [mock_sub_account],
+            "page_info": {
+                "has_next": False,
+                "has_previous": False,
+                "start_cursor": "start123",
+                "end_cursor": "end123"
+            }
+        }
+
+        with respx.mock:
+            respx.get("https://api.justifi.ai/v1/sub_accounts").mock(
+                return_value=Response(200, json=expected_response)
+            )
+
+            result = await list_sub_accounts(client, status="enabled")
+            assert result == expected_response
+
+    async def test_list_sub_accounts_with_pagination(self, client, mock_sub_account):
+        """Test listing sub accounts with pagination."""
+        expected_response = {
+            "data": [mock_sub_account],
+            "page_info": {
+                "has_next": True,
+                "has_previous": False,
+                "start_cursor": "start123",
+                "end_cursor": "end123"
+            }
+        }
+
+        with respx.mock:
+            respx.get("https://api.justifi.ai/v1/sub_accounts").mock(
+                return_value=Response(200, json=expected_response)
+            )
+
+            result = await list_sub_accounts(client, limit=10, after_cursor="cursor123")
+            assert result == expected_response
+
+    async def test_list_sub_accounts_invalid_limit(self, client):
+        """Test list_sub_accounts with invalid limit."""
+        with pytest.raises(ValidationError) as exc_info:
+            await list_sub_accounts(client, limit=0)
+
+        assert "limit must be an integer between 1 and 100" in str(exc_info.value)
+
+    async def test_list_sub_accounts_invalid_limit_too_high(self, client):
+        """Test list_sub_accounts with limit too high."""
+        with pytest.raises(ValidationError) as exc_info:
+            await list_sub_accounts(client, limit=101)
+
+        assert "limit must be an integer between 1 and 100" in str(exc_info.value)
+
+    async def test_list_sub_accounts_invalid_status(self, client):
+        """Test list_sub_accounts with invalid status."""
+        with pytest.raises(ValidationError) as exc_info:
+            await list_sub_accounts(client, status="invalid_status")
+
+        assert "status must be one of:" in str(exc_info.value)
+
+    async def test_list_sub_accounts_both_cursors(self, client):
+        """Test list_sub_accounts with both cursors specified."""
+        with pytest.raises(ValidationError) as exc_info:
+            await list_sub_accounts(client, after_cursor="after", before_cursor="before")
+
+        assert "Cannot specify both after_cursor and before_cursor" in str(exc_info.value)
+
+    async def test_list_sub_accounts_api_error(self, client):
+        """Test list_sub_accounts with API error."""
+        with respx.mock:
+            respx.get("https://api.justifi.ai/v1/sub_accounts").mock(
+                return_value=Response(500, json={"error": "Server error"})
+            )
+
+            with pytest.raises(ToolError) as exc_info:
+                await list_sub_accounts(client)
+
+            assert "Failed to list sub accounts" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+class TestGetSubAccount:
+    """Test get_sub_account function."""
+
+    async def test_get_sub_account_success(self, client, mock_sub_account):
+        """Test successful sub account retrieval."""
+        sub_account_id = "acc_test123"
+
+        with respx.mock:
+            respx.get(f"https://api.justifi.ai/v1/sub_accounts/{sub_account_id}").mock(
+                return_value=Response(200, json=mock_sub_account)
+            )
+
+            result = await get_sub_account(client, sub_account_id)
+            assert result == mock_sub_account
+
+    async def test_get_sub_account_empty_id(self, client):
+        """Test get_sub_account with empty ID."""
+        with pytest.raises(ValidationError) as exc_info:
+            await get_sub_account(client, "")
+
+        assert "sub_account_id cannot be empty or whitespace" in str(exc_info.value)
+
+    async def test_get_sub_account_none_id(self, client):
+        """Test get_sub_account with None ID."""
+        with pytest.raises(ValidationError) as exc_info:
+            await get_sub_account(client, None)
+
+        assert "sub_account_id is required and must be a non-empty string" in str(exc_info.value)
+
+    async def test_get_sub_account_whitespace_id(self, client):
+        """Test get_sub_account with whitespace ID."""
+        with pytest.raises(ValidationError) as exc_info:
+            await get_sub_account(client, "   ")
+
+        assert "sub_account_id cannot be empty or whitespace" in str(exc_info.value)
+
+    async def test_get_sub_account_not_found(self, client):
+        """Test get_sub_account with non-existent ID."""
+        sub_account_id = "acc_nonexistent"
+
+        with respx.mock:
+            respx.get(f"https://api.justifi.ai/v1/sub_accounts/{sub_account_id}").mock(
+                return_value=Response(404, json={"error": "Sub account not found"})
+            )
+
+            with pytest.raises(ToolError) as exc_info:
+                await get_sub_account(client, sub_account_id)
+
+            assert f"Failed to retrieve sub account {sub_account_id}" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+class TestGetSubAccountPayoutAccount:
+    """Test get_sub_account_payout_account function."""
+
+    async def test_get_sub_account_payout_account_success(self, client, mock_payout_account):
+        """Test successful sub account payout account retrieval."""
+        sub_account_id = "acc_test123"
+
+        with respx.mock:
+            respx.get(f"https://api.justifi.ai/v1/sub_accounts/{sub_account_id}/payout_account").mock(
+                return_value=Response(200, json=mock_payout_account)
+            )
+
+            result = await get_sub_account_payout_account(client, sub_account_id)
+            assert result == mock_payout_account
+
+    async def test_get_sub_account_payout_account_empty_id(self, client):
+        """Test get_sub_account_payout_account with empty ID."""
+        with pytest.raises(ValidationError) as exc_info:
+            await get_sub_account_payout_account(client, "")
+
+        assert "sub_account_id cannot be empty or whitespace" in str(exc_info.value)
+
+    async def test_get_sub_account_payout_account_none_id(self, client):
+        """Test get_sub_account_payout_account with None ID."""
+        with pytest.raises(ValidationError) as exc_info:
+            await get_sub_account_payout_account(client, None)
+
+        assert "sub_account_id is required and must be a non-empty string" in str(exc_info.value)
+
+    async def test_get_sub_account_payout_account_not_found(self, client):
+        """Test get_sub_account_payout_account with non-existent ID."""
+        sub_account_id = "acc_nonexistent"
+
+        with respx.mock:
+            respx.get(f"https://api.justifi.ai/v1/sub_accounts/{sub_account_id}/payout_account").mock(
+                return_value=Response(404, json={"error": "Payout account not found"})
+            )
+
+            with pytest.raises(ToolError) as exc_info:
+                await get_sub_account_payout_account(client, sub_account_id)
+
+            assert f"Failed to retrieve payout account for sub account {sub_account_id}" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+class TestGetSubAccountSettings:
+    """Test get_sub_account_settings function."""
+
+    async def test_get_sub_account_settings_success(self, client, mock_sub_account_settings):
+        """Test successful sub account settings retrieval."""
+        sub_account_id = "acc_test123"
+
+        with respx.mock:
+            respx.get(f"https://api.justifi.ai/v1/sub_accounts/{sub_account_id}/settings").mock(
+                return_value=Response(200, json=mock_sub_account_settings)
+            )
+
+            result = await get_sub_account_settings(client, sub_account_id)
+            assert result == mock_sub_account_settings
+
+    async def test_get_sub_account_settings_empty_id(self, client):
+        """Test get_sub_account_settings with empty ID."""
+        with pytest.raises(ValidationError) as exc_info:
+            await get_sub_account_settings(client, "")
+
+        assert "sub_account_id cannot be empty or whitespace" in str(exc_info.value)
+
+    async def test_get_sub_account_settings_none_id(self, client):
+        """Test get_sub_account_settings with None ID."""
+        with pytest.raises(ValidationError) as exc_info:
+            await get_sub_account_settings(client, None)
+
+        assert "sub_account_id is required and must be a non-empty string" in str(exc_info.value)
+
+    async def test_get_sub_account_settings_not_found(self, client):
+        """Test get_sub_account_settings with non-existent ID."""
+        sub_account_id = "acc_nonexistent"
+
+        with respx.mock:
+            respx.get(f"https://api.justifi.ai/v1/sub_accounts/{sub_account_id}/settings").mock(
+                return_value=Response(404, json={"error": "Settings not found"})
+            )
+
+            with pytest.raises(ToolError) as exc_info:
+                await get_sub_account_settings(client, sub_account_id)
+
+            assert f"Failed to retrieve settings for sub account {sub_account_id}" in str(exc_info.value)


### PR DESCRIPTION
Add 4 new sub account tools to the JustiFi MCP server, enabling AI agents to access sub account data through the MCP protocol.

## Changes
- **New Tools Added:** 4 sub account tools (list, get, payout account, settings)
- **Documentation Updated:** Tool counts throughout README, CLAUDE.md, and endpoint inventory
- **Testing:** 21 comprehensive test cases covering all scenarios
- **Quality Assured:** All 95 tests pass, linting clean

## Tool Count Update
- Previous: 16 tools
- Current: **20 tools** (+4 sub account tools)

Closes #65

Generated with [Claude Code](https://claude.ai/code)