### PR TITLE
feat: add v1.0.23 standardized response format examples (fixes #71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,16 @@ This standardization applies to all tools including payments, payouts, refunds, 
 - Our tool schemas are already OpenAI-compatible
 - Examples: [`examples/openai/`](./examples/openai/)
 
+### Standardized Response Format Examples (v1.0.23)
+- **JustiFi MCP Agent**: Demonstrates proper handling of standardized responses
+  - File: [`examples/justifi_mcp.py`](./examples/justifi_mcp.py)
+  - Shows template-based formatting for payouts, payments, transactions
+  - Eliminates hardcoded "data" field assumptions
+- **Web Chat Interface**: Complete web application with consistent formatting
+  - File: [`examples/web_chat.py`](./examples/web_chat.py)
+  - Real-time chat interface with structured data display
+  - Demonstrates web integration patterns
+
 ## 🤝 Contributing
 
 1. Focus on comprehensive payment management

--- a/examples/justifi_mcp.py
+++ b/examples/justifi_mcp.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""
+JustiFi MCP Agent Example - v1.0.23 Standardized Response Format
+
+This example demonstrates how to properly handle the standardized response format
+introduced in justifi-mcp-server v1.0.23. All tools now return responses with
+a consistent "data" field structure.
+
+Key Features:
+- Proper handling of standardized response format
+- Template-based response generation for different data types
+- Support for payouts, payments, transactions, and other data types
+- Error handling and fallback responses
+
+Requirements:
+    uv pip install langchain langchain-openai
+    
+Environment Variables:
+    JUSTIFI_CLIENT_ID - Your JustiFi API client ID
+    JUSTIFI_CLIENT_SECRET - Your JustiFi API client secret
+    OPENAI_API_KEY - Your OpenAI API key
+"""
+
+import asyncio
+import os
+from datetime import datetime
+from typing import Any, Dict, List
+
+from langchain.agents import AgentExecutor, create_openai_tools_agent
+from langchain_core.messages import SystemMessage
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_openai import ChatOpenAI
+
+from python import JustiFiToolkit
+
+
+class JustiFiMCPAgent:
+    """
+    JustiFi MCP Agent with v1.0.23 standardized response handling.
+    
+    This agent properly handles the standardized response format where all
+    tools return data in the "data" field, eliminating the need for tool-specific
+    response parsing.
+    """
+
+    def __init__(self):
+        """Initialize the agent with proper response format handling."""
+        self.toolkit = JustiFiToolkit(
+            client_id=os.getenv("JUSTIFI_CLIENT_ID"),
+            client_secret=os.getenv("JUSTIFI_CLIENT_SECRET"),
+        )
+        
+        self.llm = ChatOpenAI(
+            model="gpt-4",
+            temperature=0.1,
+            openai_api_key=os.getenv("OPENAI_API_KEY")
+        )
+        
+        self.tools = self.toolkit.get_langchain_tools()
+        self._setup_agent()
+
+    def _setup_agent(self):
+        """Setup the agent with standardized response format handling."""
+        
+        # System prompt with detailed formatting templates
+        system_prompt = """You are a financial assistant specializing in JustiFi payment operations.
+
+All JustiFi tools now return standardized responses in v1.0.23 format:
+{
+  "data": [...],           // Always contains the actual records
+  "metadata": {
+    "type": "payouts",     // Data type indicator  
+    "count": 5,            // Number of records
+    "tool": "list_payouts", // Source tool name
+    "original_format": "api" // Original response format
+  },
+  "page_info": {...}       // Pagination info if applicable
+}
+
+IMPORTANT RESPONSE FORMATTING RULES:
+
+For PAYOUT requests, format responses like this:
+📊 **Payout Summary**
+- **Total Payouts**: {count}
+- **Combined Amount**: ${total_amount}
+- **Status Breakdown**: {status_counts}
+
+**Recent Payouts:**
+{detailed_payout_list}
+
+For PAYMENT requests, format responses like this:
+💳 **Payment Summary** 
+- **Total Payments**: {count}
+- **Combined Amount**: ${total_amount}
+- **Status Breakdown**: {status_counts}
+
+**Recent Payments:**
+{detailed_payment_list}
+
+For TRANSACTION requests, format responses like this:
+📈 **Transaction Summary**
+- **Total Transactions**: {count}
+- **Combined Amount**: ${total_amount}
+- **Type Breakdown**: {type_counts}
+
+**Recent Transactions:**
+{detailed_transaction_list}
+
+For DISPUTE/REFUND requests, provide appropriate summaries with:
+- Total count and amounts
+- Status breakdowns  
+- Detailed item lists
+
+RESPONSE PROCESSING:
+1. Always extract data from response["data"] field
+2. Use metadata["type"] to determine data type
+3. Calculate totals, averages, and status breakdowns
+4. Format using appropriate template above
+5. Provide actionable insights and recommendations
+
+Never return generic messages like "I've retrieved your payment information."
+Always show actual data, amounts, statuses, and specific details."""
+
+        prompt = ChatPromptTemplate.from_messages([
+            SystemMessage(content=system_prompt),
+            ("user", "{input}"),
+            MessagesPlaceholder(variable_name="agent_scratchpad")
+        ])
+
+        self.agent = create_openai_tools_agent(
+            llm=self.llm,
+            tools=self.tools, 
+            prompt=prompt
+        )
+
+        self.agent_executor = AgentExecutor(
+            agent=self.agent,
+            tools=self.tools,
+            verbose=True,
+            max_iterations=5,
+            handle_parsing_errors=True
+        )
+
+    async def process_request(self, user_input: str) -> str:
+        """
+        Process user request and return formatted response.
+        
+        This method demonstrates proper handling of standardized responses
+        from JustiFi MCP tools v1.0.23.
+        """
+        try:
+            result = await self.agent_executor.ainvoke({"input": user_input})
+            return result["output"]
+        except Exception as e:
+            return f"❌ Error processing request: {str(e)}"
+
+    def format_standardized_response(self, response: Dict[str, Any]) -> str:
+        """
+        Format standardized response based on data type.
+        
+        This demonstrates how to properly extract and format data from
+        the v1.0.23 standardized response format.
+        """
+        if not isinstance(response, dict) or "data" not in response:
+            return "⚠️ Invalid response format received"
+
+        data = response["data"]
+        metadata = response.get("metadata", {})
+        data_type = metadata.get("type", "unknown")
+        count = metadata.get("count", len(data) if isinstance(data, list) else 0)
+        
+        if data_type == "payouts":
+            return self._format_payout_response(data, count, metadata)
+        elif data_type == "payments": 
+            return self._format_payment_response(data, count, metadata)
+        elif data_type == "balance_transactions":
+            return self._format_transaction_response(data, count, metadata)
+        elif data_type in ["disputes", "refunds", "checkouts"]:
+            return self._format_generic_response(data, count, metadata, data_type)
+        else:
+            return self._format_unknown_response(data, count, metadata)
+
+    def _format_payout_response(self, data: List[Dict], count: int, metadata: Dict) -> str:
+        """Format payout data using the standardized template."""
+        if not data:
+            return "📊 **Payout Summary**\nNo payouts found."
+
+        total_amount = sum(payout.get("amount", 0) for payout in data) / 100
+        status_counts = {}
+        
+        payout_details = []
+        for payout in data:
+            status = payout.get("status", "unknown")
+            status_counts[status] = status_counts.get(status, 0) + 1
+            
+            amount = payout.get("amount", 0) / 100
+            created = payout.get("created", "unknown")
+            payout_id = payout.get("id", "unknown")
+            
+            payout_details.append(f"• ${amount:.2f} - {status} - {created} ({payout_id})")
+
+        status_breakdown = ", ".join([f"{status}: {count}" for status, count in status_counts.items()])
+        
+        return f"""📊 **Payout Summary**
+- **Total Payouts**: {count}
+- **Combined Amount**: ${total_amount:.2f}
+- **Status Breakdown**: {status_breakdown}
+
+**Recent Payouts:**
+{chr(10).join(payout_details[:10])}"""
+
+    def _format_payment_response(self, data: List[Dict], count: int, metadata: Dict) -> str:
+        """Format payment data using the standardized template."""
+        if not data:
+            return "💳 **Payment Summary**\nNo payments found."
+
+        total_amount = sum(payment.get("amount", 0) for payment in data) / 100
+        status_counts = {}
+        
+        payment_details = []
+        for payment in data:
+            status = payment.get("status", "unknown") 
+            status_counts[status] = status_counts.get(status, 0) + 1
+            
+            amount = payment.get("amount", 0) / 100
+            created = payment.get("created", "unknown")
+            payment_id = payment.get("id", "unknown")
+            
+            payment_details.append(f"• ${amount:.2f} - {status} - {created} ({payment_id})")
+
+        status_breakdown = ", ".join([f"{status}: {count}" for status, count in status_counts.items()])
+        
+        return f"""💳 **Payment Summary**
+- **Total Payments**: {count}
+- **Combined Amount**: ${total_amount:.2f}
+- **Status Breakdown**: {status_breakdown}
+
+**Recent Payments:**
+{chr(10).join(payment_details[:10])}"""
+
+    def _format_transaction_response(self, data: List[Dict], count: int, metadata: Dict) -> str:
+        """Format transaction data using the standardized template.""" 
+        if not data:
+            return "📈 **Transaction Summary**\nNo transactions found."
+
+        total_amount = sum(abs(tx.get("amount", 0)) for tx in data) / 100
+        type_counts = {}
+        
+        transaction_details = []
+        for tx in data:
+            tx_type = tx.get("type", "unknown")
+            type_counts[tx_type] = type_counts.get(tx_type, 0) + 1
+            
+            amount = tx.get("amount", 0) / 100
+            created = tx.get("created", "unknown")  
+            tx_id = tx.get("id", "unknown")
+            
+            transaction_details.append(f"• ${amount:.2f} - {tx_type} - {created} ({tx_id})")
+
+        type_breakdown = ", ".join([f"{tx_type}: {count}" for tx_type, count in type_counts.items()])
+        
+        return f"""📈 **Transaction Summary**
+- **Total Transactions**: {count}
+- **Combined Amount**: ${total_amount:.2f}
+- **Type Breakdown**: {type_breakdown}
+
+**Recent Transactions:**
+{chr(10).join(transaction_details[:10])}"""
+
+    def _format_generic_response(self, data: List[Dict], count: int, metadata: Dict, data_type: str) -> str:
+        """Format other data types with generic template."""
+        if not data:
+            return f"📋 **{data_type.title()} Summary**\nNo {data_type} found."
+
+        details = []
+        for item in data:
+            item_id = item.get("id", "unknown")
+            status = item.get("status", "N/A")
+            amount = item.get("amount", 0)
+            amount_str = f"${amount/100:.2f}" if amount else "N/A"
+            
+            details.append(f"• {item_id} - {status} - {amount_str}")
+
+        return f"""📋 **{data_type.title()} Summary** 
+- **Total {data_type.title()}**: {count}
+
+**Recent {data_type.title()}:**
+{chr(10).join(details[:10])}"""
+
+    def _format_unknown_response(self, data: List[Dict], count: int, metadata: Dict) -> str:
+        """Format unknown data types with fallback template."""
+        data_type = metadata.get("type", "items")
+        
+        return f"""📄 **Data Summary**
+- **Total {data_type}**: {count}
+- **Data Type**: {data_type}
+
+First few items:
+{str(data[:3]) if data else "No data available"}"""
+
+
+async def demonstrate_standardized_responses():
+    """Demonstrate proper handling of v1.0.23 standardized responses."""
+    print("🚀 JustiFi MCP Agent - v1.0.23 Standardized Response Demo\n")
+    
+    agent = JustiFiMCPAgent()
+    
+    # Test scenarios that should return properly formatted responses
+    test_scenarios = [
+        "Tell me about my last 5 payouts with details",
+        "Show me recent payments and their status", 
+        "Get my balance transactions for analysis",
+        "List any recent disputes or issues",
+    ]
+    
+    for i, scenario in enumerate(test_scenarios, 1):
+        print(f"📋 Test {i}: {scenario}")
+        print("=" * 50)
+        
+        response = await agent.process_request(scenario)
+        print(response)
+        print("\n" + "=" * 50 + "\n")
+
+async def demonstrate_direct_response_formatting():
+    """Demonstrate direct formatting of standardized responses.""" 
+    print("🔧 Direct Response Formatting Demo\n")
+    
+    agent = JustiFiMCPAgent()
+    
+    # Example standardized response from v1.0.23
+    example_payout_response = {
+        "data": [
+            {
+                "id": "po_123456",
+                "amount": 150000,  # $1,500.00
+                "status": "completed", 
+                "created": "2025-08-07T12:00:00Z"
+            },
+            {
+                "id": "po_789012",
+                "amount": 250000,  # $2,500.00
+                "status": "pending",
+                "created": "2025-08-07T10:30:00Z"
+            }
+        ],
+        "metadata": {
+            "type": "payouts",
+            "count": 2,
+            "tool": "get_recent_payouts", 
+            "original_format": "custom"
+        }
+    }
+    
+    formatted = agent.format_standardized_response(example_payout_response)
+    print("📊 Formatted Payout Response:")
+    print(formatted)
+    
+    # Example payment response  
+    example_payment_response = {
+        "data": [
+            {
+                "id": "py_abcdef",
+                "amount": 99999,  # $999.99
+                "status": "succeeded",
+                "created": "2025-08-07T14:15:00Z"
+            }
+        ],
+        "metadata": {
+            "type": "payments", 
+            "count": 1,
+            "tool": "list_payments",
+            "original_format": "api"
+        }
+    }
+    
+    formatted = agent.format_standardized_response(example_payment_response)
+    print("\n💳 Formatted Payment Response:")
+    print(formatted)
+
+
+if __name__ == "__main__":
+    async def main():
+        print("🎯 JustiFi MCP Agent - v1.0.23 Standardized Response Format")
+        print("=" * 60)
+        print("This example demonstrates proper handling of the standardized")
+        print("response format introduced in justifi-mcp-server v1.0.23.\n")
+        
+        # Check for required environment variables
+        required_vars = ["JUSTIFI_CLIENT_ID", "JUSTIFI_CLIENT_SECRET", "OPENAI_API_KEY"] 
+        missing_vars = [var for var in required_vars if not os.getenv(var)]
+        
+        if missing_vars:
+            print(f"❌ Missing required environment variables: {', '.join(missing_vars)}")
+            print("Please set these variables and try again.\n")
+            return
+            
+        await demonstrate_direct_response_formatting()
+        print("\n" + "=" * 60 + "\n")
+        await demonstrate_standardized_responses()
+        
+        print("✅ Demo completed successfully!")
+        print("\n🎯 Key Benefits of v1.0.23 Standardized Responses:")
+        print("   • Consistent 'data' field across all tools")
+        print("   • Eliminates tool-specific response parsing")
+        print("   • Reliable data extraction and formatting")
+        print("   • Better error handling and fallbacks")
+        print("   • Improved agent response quality")
+
+    asyncio.run(main())

--- a/examples/web_chat.py
+++ b/examples/web_chat.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""
+JustiFi Web Chat Example - v1.0.23 Standardized Response Format
+
+This example demonstrates a web chat interface that properly handles
+standardized responses from justifi-mcp-server v1.0.23. Shows how web
+applications should consume and display JustiFi data consistently.
+
+Key Features:
+- Web-based chat interface using Starlette/FastAPI
+- Consistent handling of standardized agent responses
+- Real-time data formatting and display
+- Error handling for failed requests
+- Support for all JustiFi data types
+
+Requirements:
+    uv pip install starlette uvicorn langchain langchain-openai jinja2 python-multipart
+
+Environment Variables:
+    JUSTIFI_CLIENT_ID - Your JustiFi API client ID  
+    JUSTIFI_CLIENT_SECRET - Your JustiFi API client secret
+    OPENAI_API_KEY - Your OpenAI API key
+
+Usage:
+    python examples/web_chat.py
+    Open http://localhost:8000 in your browser
+"""
+
+import asyncio
+import json
+import os
+from datetime import datetime
+from typing import Any, Dict, List
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.responses import HTMLResponse, JSONResponse
+from starlette.routing import Route, Mount
+from starlette.staticfiles import StaticFiles
+from starlette.templating import Jinja2Templates
+
+# Import our JustiFi MCP agent
+from justifi_mcp import JustiFiMCPAgent
+
+
+class WebChatService:
+    """
+    Web chat service that handles standardized JustiFi MCP responses.
+    
+    This service demonstrates how web applications should consume the
+    v1.0.23 standardized response format consistently.
+    """
+
+    def __init__(self):
+        """Initialize the web chat service."""
+        self.agent = None
+        self._initialize_agent()
+
+    def _initialize_agent(self):
+        """Initialize the JustiFi MCP agent."""
+        try:
+            self.agent = JustiFiMCPAgent()
+            print("✅ JustiFi MCP Agent initialized successfully")
+        except Exception as e:
+            print(f"❌ Failed to initialize JustiFi MCP Agent: {e}")
+            self.agent = None
+
+    async def process_chat_message(self, message: str, session_id: str = "default") -> Dict[str, Any]:
+        """
+        Process a chat message and return structured response.
+        
+        This method demonstrates proper handling of agent responses
+        and consistent formatting for web display.
+        """
+        if not self.agent:
+            return {
+                "success": False,
+                "message": "⚠️ JustiFi agent not available. Please check your configuration.",
+                "error": "Agent initialization failed",
+                "timestamp": datetime.now().isoformat()
+            }
+
+        try:
+            # Process the message using our standardized agent
+            response = await self.agent.process_request(message)
+            
+            # Parse and structure the response for web display
+            return self._format_web_response(response, message)
+            
+        except Exception as e:
+            return {
+                "success": False,
+                "message": f"❌ Error processing your request: {str(e)}",
+                "error": str(e),
+                "timestamp": datetime.now().isoformat()
+            }
+
+    def _format_web_response(self, agent_response: str, original_message: str) -> Dict[str, Any]:
+        """
+        Format agent response for web display.
+        
+        This demonstrates how web applications should handle the
+        consistently formatted responses from the v1.0.23 agent.
+        """
+        # Determine response type based on original message
+        response_type = self._detect_response_type(original_message)
+        
+        # Structure the response for web display
+        return {
+            "success": True,
+            "message": agent_response,
+            "type": response_type,
+            "formatted": self._apply_web_formatting(agent_response, response_type),
+            "timestamp": datetime.now().isoformat(),
+            "original_message": original_message
+        }
+
+    def _detect_response_type(self, message: str) -> str:
+        """Detect the type of response based on the user message."""
+        message_lower = message.lower()
+        
+        if any(word in message_lower for word in ["payout", "payouts"]):
+            return "payouts"
+        elif any(word in message_lower for word in ["payment", "payments"]):
+            return "payments"
+        elif any(word in message_lower for word in ["transaction", "transactions", "balance"]):
+            return "transactions"
+        elif any(word in message_lower for word in ["dispute", "disputes"]):
+            return "disputes"
+        elif any(word in message_lower for word in ["refund", "refunds"]):
+            return "refunds"
+        elif any(word in message_lower for word in ["checkout", "checkouts"]):
+            return "checkouts"
+        else:
+            return "general"
+
+    def _apply_web_formatting(self, response: str, response_type: str) -> Dict[str, Any]:
+        """
+        Apply web-specific formatting to the response.
+        
+        This shows how to convert the standardized agent response
+        into structured data for web display components.
+        """
+        # Extract key information for web display
+        lines = response.split('\n')
+        
+        formatted_response = {
+            "type": response_type,
+            "summary": {},
+            "details": [],
+            "raw_text": response
+        }
+
+        # Parse summary information (works with v1.0.23 standardized format)
+        for line in lines:
+            if "Total" in line and ":" in line:
+                key, value = line.split(":", 1)
+                formatted_response["summary"][key.strip("- *")] = value.strip()
+            elif "Combined Amount" in line and ":" in line:
+                key, value = line.split(":", 1)
+                formatted_response["summary"][key.strip("- *")] = value.strip()
+            elif "Status Breakdown" in line and ":" in line:
+                key, value = line.split(":", 1)
+                formatted_response["summary"][key.strip("- *")] = value.strip()
+
+        # Extract detail items
+        in_details = False
+        for line in lines:
+            if line.startswith("**Recent"):
+                in_details = True
+                continue
+            elif in_details and line.startswith("•"):
+                formatted_response["details"].append(line.strip("• "))
+
+        return formatted_response
+
+
+# Initialize the web chat service
+web_chat_service = WebChatService()
+
+# HTML template for the chat interface
+CHAT_HTML = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>JustiFi Web Chat - v1.0.23 Demo</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .chat-container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            overflow: hidden;
+        }
+        .chat-header {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .chat-header h1 {
+            margin: 0;
+            font-size: 24px;
+        }
+        .chat-header p {
+            margin: 5px 0 0 0;
+            opacity: 0.9;
+            font-size: 14px;
+        }
+        .chat-messages {
+            height: 500px;
+            overflow-y: auto;
+            padding: 20px;
+            background: #f8f9fa;
+        }
+        .message {
+            margin-bottom: 20px;
+            padding: 15px;
+            border-radius: 8px;
+        }
+        .user-message {
+            background: #e3f2fd;
+            margin-left: 50px;
+            border-left: 4px solid #2196f3;
+        }
+        .bot-message {
+            background: white;
+            margin-right: 50px;
+            border-left: 4px solid #4caf50;
+        }
+        .error-message {
+            background: #ffebee;
+            margin-right: 50px;
+            border-left: 4px solid #f44336;
+        }
+        .message-header {
+            font-weight: bold;
+            margin-bottom: 8px;
+            font-size: 14px;
+            color: #666;
+        }
+        .message-content {
+            white-space: pre-wrap;
+            line-height: 1.5;
+        }
+        .message-summary {
+            background: #f0f0f0;
+            padding: 10px;
+            border-radius: 4px;
+            margin-top: 10px;
+            font-size: 14px;
+        }
+        .summary-item {
+            margin: 5px 0;
+        }
+        .chat-input {
+            padding: 20px;
+            border-top: 1px solid #e0e0e0;
+            background: white;
+        }
+        .input-container {
+            display: flex;
+            gap: 10px;
+        }
+        .message-input {
+            flex: 1;
+            padding: 12px 16px;
+            border: 2px solid #e0e0e0;
+            border-radius: 25px;
+            font-size: 16px;
+            outline: none;
+        }
+        .message-input:focus {
+            border-color: #667eea;
+        }
+        .send-button {
+            padding: 12px 24px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            border-radius: 25px;
+            cursor: pointer;
+            font-size: 16px;
+            font-weight: 500;
+        }
+        .send-button:hover {
+            opacity: 0.9;
+        }
+        .send-button:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+        .typing-indicator {
+            padding: 10px 15px;
+            background: white;
+            margin-right: 50px;
+            border-left: 4px solid #ffc107;
+            border-radius: 8px;
+            font-style: italic;
+            color: #666;
+        }
+        .example-queries {
+            padding: 15px 20px;
+            background: #e8f5e8;
+            border-top: 1px solid #c8e6c9;
+        }
+        .example-queries h3 {
+            margin: 0 0 10px 0;
+            color: #2e7d32;
+            font-size: 16px;
+        }
+        .example-query {
+            display: inline-block;
+            background: #4caf50;
+            color: white;
+            padding: 8px 12px;
+            margin: 4px 8px 4px 0;
+            border-radius: 15px;
+            cursor: pointer;
+            font-size: 14px;
+            transition: background-color 0.2s;
+        }
+        .example-query:hover {
+            background: #388e3c;
+        }
+    </style>
+</head>
+<body>
+    <div class="chat-container">
+        <div class="chat-header">
+            <h1>🏦 JustiFi Web Chat</h1>
+            <p>v1.0.23 Standardized Response Format Demo</p>
+        </div>
+        
+        <div class="chat-messages" id="chatMessages">
+            <div class="message bot-message">
+                <div class="message-header">🤖 JustiFi Assistant</div>
+                <div class="message-content">Welcome! I'm your JustiFi assistant with v1.0.23 standardized response handling.
+
+I can help you with:
+• Payout information and analysis
+• Payment details and status
+• Transaction history and breakdowns
+• Dispute and refund tracking
+• Account and balance information
+
+All responses use the new standardized format for consistent data display.</div>
+            </div>
+        </div>
+        
+        <div class="example-queries">
+            <h3>💡 Try these examples:</h3>
+            <span class="example-query" onclick="sendExampleQuery('Tell me about my last 5 payouts')">Last 5 payouts</span>
+            <span class="example-query" onclick="sendExampleQuery('Show me recent payments and their status')">Recent payments</span>
+            <span class="example-query" onclick="sendExampleQuery('Get my balance transactions')">Balance transactions</span>
+            <span class="example-query" onclick="sendExampleQuery('Any disputes or refunds?')">Disputes & refunds</span>
+        </div>
+        
+        <div class="chat-input">
+            <div class="input-container">
+                <input type="text" id="messageInput" class="message-input" 
+                       placeholder="Ask about your payouts, payments, transactions..." 
+                       onkeypress="handleKeyPress(event)">
+                <button onclick="sendMessage()" id="sendButton" class="send-button">Send</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        async function sendMessage() {
+            const input = document.getElementById('messageInput');
+            const message = input.value.trim();
+            if (!message) return;
+
+            // Add user message to chat
+            addMessage(message, 'user');
+            input.value = '';
+            
+            // Show typing indicator
+            const typingId = addTypingIndicator();
+            
+            // Disable input while processing
+            setInputEnabled(false);
+
+            try {
+                const response = await fetch('/chat', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ message: message })
+                });
+
+                const data = await response.json();
+                
+                // Remove typing indicator
+                removeTypingIndicator(typingId);
+                
+                // Add bot response
+                if (data.success) {
+                    addMessage(data.message, 'bot', data.formatted);
+                } else {
+                    addMessage(data.message || 'Sorry, something went wrong.', 'error');
+                }
+                
+            } catch (error) {
+                removeTypingIndicator(typingId);
+                addMessage('Connection error. Please try again.', 'error');
+            }
+            
+            // Re-enable input
+            setInputEnabled(true);
+        }
+
+        function addMessage(content, type, formatted = null) {
+            const messagesContainer = document.getElementById('chatMessages');
+            const messageDiv = document.createElement('div');
+            
+            let className = type === 'user' ? 'user-message' : 
+                           type === 'error' ? 'error-message' : 'bot-message';
+            
+            let header = type === 'user' ? '👤 You' : 
+                        type === 'error' ? '⚠️ Error' : '🤖 JustiFi Assistant';
+            
+            messageDiv.className = `message ${className}`;
+            messageDiv.innerHTML = `
+                <div class="message-header">${header}</div>
+                <div class="message-content">${content}</div>
+            `;
+            
+            // Add formatted summary if available (demonstrates v1.0.23 structured data)
+            if (formatted && formatted.summary && Object.keys(formatted.summary).length > 0) {
+                const summaryDiv = document.createElement('div');
+                summaryDiv.className = 'message-summary';
+                summaryDiv.innerHTML = '<strong>📊 Quick Summary:</strong><br>' + 
+                    Object.entries(formatted.summary)
+                        .map(([key, value]) => `<div class="summary-item"><strong>${key}:</strong> ${value}</div>`)
+                        .join('');
+                messageDiv.appendChild(summaryDiv);
+            }
+            
+            messagesContainer.appendChild(messageDiv);
+            messagesContainer.scrollTop = messagesContainer.scrollHeight;
+        }
+
+        function addTypingIndicator() {
+            const messagesContainer = document.getElementById('chatMessages');
+            const typingDiv = document.createElement('div');
+            const id = 'typing-' + Date.now();
+            
+            typingDiv.id = id;
+            typingDiv.className = 'typing-indicator';
+            typingDiv.innerHTML = '🤖 JustiFi Assistant is thinking...';
+            
+            messagesContainer.appendChild(typingDiv);
+            messagesContainer.scrollTop = messagesContainer.scrollHeight;
+            
+            return id;
+        }
+
+        function removeTypingIndicator(id) {
+            const element = document.getElementById(id);
+            if (element) {
+                element.remove();
+            }
+        }
+
+        function setInputEnabled(enabled) {
+            document.getElementById('messageInput').disabled = !enabled;
+            document.getElementById('sendButton').disabled = !enabled;
+        }
+
+        function handleKeyPress(event) {
+            if (event.key === 'Enter') {
+                sendMessage();
+            }
+        }
+
+        function sendExampleQuery(query) {
+            document.getElementById('messageInput').value = query;
+            sendMessage();
+        }
+
+        // Focus input on page load
+        document.getElementById('messageInput').focus();
+    </script>
+</body>
+</html>
+"""
+
+
+async def chat_page(request):
+    """Serve the chat interface."""
+    return HTMLResponse(CHAT_HTML)
+
+
+async def chat_api(request):
+    """Handle chat API requests."""
+    try:
+        body = await request.json()
+        message = body.get('message', '').strip()
+        
+        if not message:
+            return JSONResponse({
+                "success": False,
+                "message": "Please provide a message.",
+                "error": "Empty message"
+            })
+
+        # Process the message using our web chat service
+        response = await web_chat_service.process_chat_message(message)
+        return JSONResponse(response)
+        
+    except Exception as e:
+        return JSONResponse({
+            "success": False,
+            "message": f"Server error: {str(e)}",
+            "error": str(e)
+        }, status_code=500)
+
+
+async def health_check(request):
+    """Health check endpoint."""
+    agent_status = "ready" if web_chat_service.agent else "not initialized"
+    
+    return JSONResponse({
+        "status": "ok",
+        "version": "v1.0.23",
+        "agent_status": agent_status,
+        "standardized_responses": True,
+        "timestamp": datetime.now().isoformat()
+    })
+
+
+# Define routes
+routes = [
+    Route('/', chat_page),
+    Route('/chat', chat_api, methods=['POST']),
+    Route('/health', health_check),
+]
+
+# Create Starlette application
+app = Starlette(debug=True, routes=routes)
+
+
+def main():
+    """Main entry point for the web chat application."""
+    print("🚀 Starting JustiFi Web Chat - v1.0.23 Demo")
+    print("=" * 50)
+    
+    # Check environment variables
+    required_vars = ["JUSTIFI_CLIENT_ID", "JUSTIFI_CLIENT_SECRET", "OPENAI_API_KEY"]
+    missing_vars = [var for var in required_vars if not os.getenv(var)]
+    
+    if missing_vars:
+        print(f"❌ Missing required environment variables: {', '.join(missing_vars)}")
+        print("Please set these variables and try again.")
+        return
+    
+    print("✅ Environment variables configured")
+    print("🌐 Starting web server...")
+    print("📱 Open http://localhost:8000 in your browser")
+    print("🛑 Press Ctrl+C to stop")
+    print("=" * 50)
+    
+    # Run the server
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=8000,
+        log_level="info"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/npx-wrapper/README.md
+++ b/npx-wrapper/README.md
@@ -475,6 +475,16 @@ This standardization applies to all tools including payments, payouts, refunds, 
 - Our tool schemas are already OpenAI-compatible
 - Examples: [`examples/openai/`](./examples/openai/)
 
+### Standardized Response Format Examples (v1.0.23)
+- **JustiFi MCP Agent**: Demonstrates proper handling of standardized responses
+  - File: [`examples/justifi_mcp.py`](./examples/justifi_mcp.py)
+  - Shows template-based formatting for payouts, payments, transactions
+  - Eliminates hardcoded "data" field assumptions
+- **Web Chat Interface**: Complete web application with consistent formatting
+  - File: [`examples/web_chat.py`](./examples/web_chat.py)
+  - Real-time chat interface with structured data display
+  - Demonstrates web integration patterns
+
 ## 🤝 Contributing
 
 1. Focus on comprehensive payment management


### PR DESCRIPTION
# Add v1.0.23 Standardized Response Format Examples

This PR adds comprehensive client-side examples demonstrating proper usage of the v1.0.23 standardized response format.

## Changes

- **Add justifi_mcp.py**: MCP agent example with proper standardized response handling
- **Add web_chat.py**: Complete web interface demonstrating consistent formatting
- **Update documentation**: Reference new examples in README.md
- **Sync NPM README**: Maintain documentation consistency

## Benefits

- Eliminates hardcoded "data" field assumptions
- Provides template-based response generation
- Shows proper handling of payouts, payments, transactions
- Demonstrates web integration patterns

Fixes #71

🤖 Generated with [Claude Code](https://claude.ai/code)