### PR TITLE
fix: resolve tool integration failures for proceed tools and sub-account type annotations

### DIFF
--- a/modelcontextprotocol/server.py
+++ b/modelcontextprotocol/server.py
@@ -339,10 +339,10 @@ def register_tools(mcp: FastMCP, client: JustiFiClient) -> None:
     # Sub Account tools
     @mcp.tool
     async def list_sub_accounts(
-        status: str = None,
+        status: str | None = None,
         limit: int = 25,
-        after_cursor: str = None,
-        before_cursor: str = None,
+        after_cursor: str | None = None,
+        before_cursor: str | None = None,
     ) -> dict[str, Any]:
         """List sub accounts with optional status filtering and pagination.
 
@@ -406,3 +406,42 @@ def register_tools(mcp: FastMCP, client: JustiFiClient) -> None:
         )
 
         return await _get_sub_account_settings(client, sub_account_id)
+
+    # Proceed tools
+    @mcp.tool
+    async def list_proceeds(
+        limit: int = 25,
+        after_cursor: str | None = None,
+        before_cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """List proceeds with optional pagination using cursor-based pagination.
+
+        Args:
+            limit: Number of proceeds to return (1-100, default: 25)
+            after_cursor: Cursor for pagination - returns results after this cursor
+            before_cursor: Cursor for pagination - returns results before this cursor
+
+        Returns:
+            Paginated list of proceeds with page_info for navigation
+        """
+        from python.tools.proceeds import list_proceeds as _list_proceeds
+
+        return await wrap_tool_call(
+            "list_proceeds", _list_proceeds, client, limit, after_cursor, before_cursor
+        )
+
+    @mcp.tool
+    async def retrieve_proceed(proceed_id: str) -> dict[str, Any]:
+        """Retrieve detailed information about a specific proceed by ID.
+
+        Args:
+            proceed_id: The unique identifier for the proceed (e.g., 'pr_ABC123XYZ')
+
+        Returns:
+            Proceed object with ID, status, amount, and details
+        """
+        from python.tools.proceeds import retrieve_proceed as _retrieve_proceed
+
+        return await wrap_tool_call(
+            "retrieve_proceed", _retrieve_proceed, client, proceed_id
+        )

--- a/python/tools/__init__.py
+++ b/python/tools/__init__.py
@@ -12,6 +12,7 @@ from .payouts import (
     list_payouts,
     retrieve_payout,
 )
+from .proceeds import list_proceeds, retrieve_proceed
 from .refunds import list_payment_refunds, list_refunds, retrieve_refund
 from .response_formatter import standardize_response
 from .response_wrapper import wrap_tool_call
@@ -37,7 +38,9 @@ __all__ = [
     "list_payouts",
     "retrieve_payout",
     "list_payment_refunds",
+    "list_proceeds",
     "list_refunds",
+    "retrieve_proceed",
     "retrieve_refund",
     "get_sub_account",
     "get_sub_account_payout_account",


### PR DESCRIPTION
Fixes #76: Tool Integration Failures

## Summary
Resolved two critical tool integration issues:
- Fixed missing proceed tools integration (completely non-functional)
- Fixed sub-account tools type annotation mismatches causing intermittent failures

## Changes Made
### Phase 1: Proceed Tool Integration
- Added `list_proceeds` and `retrieve_proceed` exports to `python/tools/__init__.py`
- Registered both proceed tools in FastMCP server with proper type annotations
- Tools now properly integrated with all existing functionality

### Phase 2: Sub-Account Type Annotations
- Updated type annotations from `str = None` to `str | None = None`
- Resolves intermittent "tool not available" type validation failures

## Verification
- ✅ All 122 tests passed
- ✅ Linting checks passed
- ✅ Changes verified with git diff and file reading

## Expected Results
- **Tool Count**: 22 total tools (20 existing + 2 proceed tools)
- **Client Applications**: All tools accessible without "not available" errors
- **Type Safety**: No more type validation failures for sub-account tools
- **Reliability**: Consistent tool availability across all integration points

Generated with [Claude Code](https://claude.ai/code)