### PR TITLE
docs: update README to include terminal tools (fixes #102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ This MCP server provides complete payment management capabilities across multipl
 - `get_sub_account_payout_account` - Get sub account payout account
 - `get_sub_account_settings` - Get sub account settings
 
+### Terminal Tools
+- `list_terminals` - List terminals with filtering and pagination
+- `retrieve_terminal` - Get detailed terminal information
+- `update_terminal` - Update terminal properties (nickname)
+- `get_terminal_status` - Get real-time terminal status
+- `identify_terminal` - Display identification on terminal screen
+
 
 
 ## 🚀 Quick Start
@@ -325,6 +332,8 @@ After configuration, restart Claude Desktop and you should see JustiFi payment t
 - "List recent payouts"
 - "Get the status of payout po_ABC123"
 - "Show me payment details for py_XYZ789"
+- "List all terminals"
+- "Get terminal status for trm_ABC123"
 
 ## 🌐 Environment Variables
 
@@ -384,7 +393,7 @@ make drift-check
 
 ## 📋 Standardized Response Format
 
-All 27 JustiFi MCP tools return responses in a consistent, standardized format to ensure uniform handling across different AI agents and applications:
+All 32 JustiFi MCP tools return responses in a consistent, standardized format to ensure uniform handling across different AI agents and applications:
 
 ```json
 {
@@ -461,7 +470,7 @@ All 27 JustiFi MCP tools return responses in a consistent, standardized format t
 }
 ```
 
-This standardization applies to all tools including payments, payouts, refunds, disputes, checkouts, balance transactions, payment methods, sub-accounts, and proceeds.
+This standardization applies to all tools including payments, payouts, refunds, disputes, checkouts, balance transactions, payment methods, sub-accounts, proceeds, and terminals.
 
 ## 📚 Documentation
 

--- a/npx-wrapper/README.md
+++ b/npx-wrapper/README.md
@@ -101,6 +101,13 @@ This MCP server provides complete payment management capabilities across multipl
 - `get_sub_account_payout_account` - Get sub account payout account
 - `get_sub_account_settings` - Get sub account settings
 
+### Terminal Tools
+- `list_terminals` - List terminals with filtering and pagination
+- `retrieve_terminal` - Get detailed terminal information
+- `update_terminal` - Update terminal properties (nickname)
+- `get_terminal_status` - Get real-time terminal status
+- `identify_terminal` - Display identification on terminal screen
+
 
 
 ## 🚀 Quick Start
@@ -325,6 +332,8 @@ After configuration, restart Claude Desktop and you should see JustiFi payment t
 - "List recent payouts"
 - "Get the status of payout po_ABC123"
 - "Show me payment details for py_XYZ789"
+- "List all terminals"
+- "Get terminal status for trm_ABC123"
 
 ## 🌐 Environment Variables
 
@@ -384,7 +393,7 @@ make drift-check
 
 ## 📋 Standardized Response Format
 
-All 27 JustiFi MCP tools return responses in a consistent, standardized format to ensure uniform handling across different AI agents and applications:
+All 32 JustiFi MCP tools return responses in a consistent, standardized format to ensure uniform handling across different AI agents and applications:
 
 ```json
 {
@@ -461,7 +470,7 @@ All 27 JustiFi MCP tools return responses in a consistent, standardized format t
 }
 ```
 
-This standardization applies to all tools including payments, payouts, refunds, disputes, checkouts, balance transactions, payment methods, sub-accounts, and proceeds.
+This standardization applies to all tools including payments, payouts, refunds, disputes, checkouts, balance transactions, payment methods, sub-accounts, proceeds, and terminals.
 
 ## 📚 Documentation
 


### PR DESCRIPTION
This PR updates the documentation to include the 5 new terminal management tools that were recently added.

## Changes
- Add Terminal Tools section with all 5 terminal management tools
- Update tool count from 27 to 32 tools in standardized response format
- Add terminal tools to the list of tools using standardized responses
- Add terminal examples to MCP integration verification section
- Sync npm README.md to match main README.md

Fixes #102

Generated with [Claude Code](https://claude.ai/code)